### PR TITLE
refactor: VSCode events bridging

### DIFF
--- a/src/message/bus.ts
+++ b/src/message/bus.ts
@@ -18,8 +18,18 @@ import { mapValues } from '../utils'
 
 export function observeServerEvents(
   bus: MessageBus<Events, Commands>,
-  vueFiles: Record<string, VueFile>
+  vueFiles: Record<string, VueFile>,
+  activeUri: string | undefined
 ): void {
+  let lastActiveUri: string | undefined = activeUri
+
+  bus.on('initClient', () => {
+    bus.emit('initProject', mapValues(vueFiles, vueFileToPayload))
+    if (lastActiveUri) {
+      bus.emit('changeDocument', lastActiveUri)
+    }
+  })
+
   bus.on('selectNode', payload => {
     const vueFile = vueFiles[payload.uri]
     if (!vueFile || !vueFile.template || payload.path.length === 0) {
@@ -92,6 +102,7 @@ export function observeServerEvents(
   })
 
   bus.on('changeActiveEditor', uri => {
+    lastActiveUri = uri
     bus.emit('changeDocument', uri)
   })
 

--- a/src/message/bus.ts
+++ b/src/message/bus.ts
@@ -90,4 +90,16 @@ export function observeServerEvents(
     // TODO: change this notification more clean and optimized way
     bus.emit('initProject', mapValues(vueFiles, vueFileToPayload))
   })
+
+  bus.on('changeActiveEditor', uri => {
+    bus.emit('changeDocument', uri)
+  })
+
+  bus.on('updateEditor', ({ uri, code }) => {
+    // TODO: move mutation to outside of this logic
+    vueFiles[uri] = parseVueFile(code, uri)
+
+    // TODO: change this notification more clean and optimized way
+    bus.emit('initProject', mapValues(vueFiles, vueFileToPayload))
+  })
 }

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -2,6 +2,7 @@ import { RuleForPrint } from '../parser/style/types'
 import { VueFilePayload } from '../parser/vue-file'
 
 export interface Events {
+  initClient: undefined
   selectNode: {
     uri: string
     path: number[]

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -11,6 +11,11 @@ export interface Events {
     nodeUri: string
     path: number[]
   }
+  changeActiveEditor: string
+  updateEditor: {
+    uri: string
+    code: string
+  }
 }
 
 export interface Commands {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -67,6 +67,9 @@ export function wsEventObserver(
 ): EventObserver<Events> {
   return new EventObserver(emit => {
     server.on('connection', ws => {
+      console.log('Client connected')
+      emit('initClient', undefined)
+
       ws.on('message', data => {
         const payload: ClientPayload = JSON.parse(data.toString())
         console.log('[receive] ' + payload.type, payload)


### PR DESCRIPTION
This is continuous refactoring following #2 and #3.
In this PR, I've wrapped vscode related events by using `meck` EventObserver so that it is now separated with the main logic.

The watcher events are still directly used in main logic. We may need some wrapper module of watcher to separate them.