### PR TITLE
feat: support updating style declaration in preview

### DIFF
--- a/src/message/bus.ts
+++ b/src/message/bus.ts
@@ -12,7 +12,8 @@ import {
   Modifiers,
   insertToTemplate,
   insertComponentScript,
-  modify
+  modify,
+  updateDeclaration
 } from '../parser/modifier'
 import { mapValues } from '../utils'
 
@@ -132,6 +133,22 @@ export function observeServerEvents(
 
   bus.on('removeDocument', uri => {
     delete vueFiles[uri]
+
+    // TODO: change this notification more clean and optimized way
+    bus.emit('initProject', mapValues(vueFiles, vueFileToPayload))
+  })
+
+  bus.on('updateDeclaration', ({ uri, declaration }) => {
+    const { code, styles } = vueFiles[uri]
+    const updated = modify(code, [updateDeclaration(styles, declaration)])
+
+    bus.emit('updateEditor', {
+      uri,
+      code: updated
+    })
+
+    // TODO: move mutation to outside of this logic
+    vueFiles[uri] = parseVueFile(updated, uri)
 
     // TODO: change this notification more clean and optimized way
     bus.emit('initProject', mapValues(vueFiles, vueFileToPayload))

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -1,4 +1,4 @@
-import { RuleForPrint } from '../parser/style/types'
+import { RuleForPrint, DeclarationUpdater } from '../parser/style/types'
 import { VueFilePayload } from '../parser/vue-file'
 
 export interface Events {
@@ -26,6 +26,10 @@ export interface Events {
     code: string
   }
   removeDocument: string
+  updateDeclaration: {
+    uri: string
+    declaration: DeclarationUpdater
+  }
 }
 
 export interface Commands {

--- a/src/parser/modifier.ts
+++ b/src/parser/modifier.ts
@@ -1,9 +1,12 @@
 import assert from 'assert'
 import * as t from '@babel/types'
-import { flatten } from '../utils'
+import { flatten, clone } from '../utils'
 import { Template, TextNode, ElementChild, Element } from './template/types'
 import { getNode } from './template/manipulate'
 import { findComponentOptions, findProperty } from './script/manipulate'
+import { DeclarationUpdater, Style } from './style/types'
+import { getDeclaration } from './style/manipulate'
+import { genDeclaration } from './style/codegen'
 
 export type Modifiers = (Modifier | Modifier[])[]
 
@@ -294,4 +297,17 @@ function inferScriptIndent(code: string, node: t.Node): string {
   } else {
     return ''
   }
+}
+
+export function updateDeclaration(
+  styles: Style[],
+  decl: DeclarationUpdater
+): Modifier[] {
+  const target = getDeclaration(styles, decl.path)
+
+  if (!target) {
+    return [empty]
+  }
+
+  return replace(target, genDeclaration(clone(target, decl)))
 }

--- a/src/parser/style/codegen.ts
+++ b/src/parser/style/codegen.ts
@@ -117,7 +117,7 @@ function genPseudoClass(node: t.PseudoClass): string {
   }
 }
 
-function genDeclaration(decl: t.Declaration): string {
+export function genDeclaration(decl: t.Declaration): string {
   let buf = decl.prop + ': ' + decl.value
 
   if (decl.important) {

--- a/src/parser/style/manipulate.ts
+++ b/src/parser/style/manipulate.ts
@@ -43,3 +43,25 @@ export function addScope(node: t.Style, scope: string): t.Style {
     })
   })
 }
+
+export function getDeclaration(
+  styles: t.Style[],
+  path: number[]
+): t.Declaration | undefined {
+  const res = path.reduce<any | undefined>(
+    (acc, i) => {
+      if (!acc) return
+
+      if (acc.children) {
+        return acc.children[i]
+      } else if (acc.body) {
+        return acc.body[i]
+      } else if (acc.declarations) {
+        return acc.declarations[i]
+      }
+    },
+    { children: styles }
+  )
+
+  return res && res.type === 'Declaration' ? res : undefined
+}

--- a/src/parser/style/transform.ts
+++ b/src/parser/style/transform.ts
@@ -5,9 +5,14 @@ import { genSelector } from './codegen'
 import * as t from './types'
 import { takeWhile, dropWhile } from '../../utils'
 
-export function transformStyle(root: postcss.Root, code: string): t.Style {
+export function transformStyle(
+  root: postcss.Root,
+  code: string,
+  index: number
+): t.Style {
   if (!root.nodes) {
     return {
+      path: [index],
       body: [],
       range: [-1, -1]
     }
@@ -16,9 +21,9 @@ export function transformStyle(root: postcss.Root, code: string): t.Style {
     .map((node, i) => {
       switch (node.type) {
         case 'atrule':
-          return transformAtRule(node, [i], code)
+          return transformAtRule(node, [index, i], code)
         case 'rule':
-          return transformRule(node, [i], code)
+          return transformRule(node, [index, i], code)
         default:
           return undefined
       }
@@ -28,6 +33,7 @@ export function transformStyle(root: postcss.Root, code: string): t.Style {
     })
 
   return {
+    path: [index],
     body,
     range: toRange(root.source, code)
   }

--- a/src/parser/style/types.ts
+++ b/src/parser/style/types.ts
@@ -82,7 +82,6 @@ export interface DeclarationForPrint {
   path: number[]
   prop: string
   value: string
-  important: boolean
 }
 
 /**

--- a/src/parser/style/types.ts
+++ b/src/parser/style/types.ts
@@ -1,6 +1,7 @@
 import { Range } from '../modifier'
 
 export interface Style extends Range {
+  path: [number]
   body: (AtRule | Rule)[]
 }
 

--- a/src/parser/style/types.ts
+++ b/src/parser/style/types.ts
@@ -84,3 +84,13 @@ export interface DeclarationForPrint {
   value: string
   important: boolean
 }
+
+/**
+ * Used to update ast
+ */
+export interface DeclarationUpdater {
+  path: number[]
+  prop?: string
+  value?: string
+  important?: boolean
+}

--- a/src/parser/vue-file.ts
+++ b/src/parser/vue-file.ts
@@ -62,8 +62,8 @@ export function parseVueFile(code: string, uri: string): VueFile {
     return resolved.toString()
   })
 
-  const styleAsts = styles.map(s => {
-    return transformStyle(postcssParse(s.content), s.content)
+  const styleAsts = styles.map((s, i) => {
+    return transformStyle(postcssParse(s.content), s.content, i)
   })
 
   return {

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -1,8 +1,8 @@
 import { VueFilePayload } from './parser/vue-file'
-import { RuleForPrint } from './parser/style/types'
+import { RuleForPrint, DeclarationUpdater } from './parser/style/types'
 
 export type ServerPayload = InitProject | ChangeDocument | MatchRules
-export type ClientPayload = SelectNode | AddNode
+export type ClientPayload = SelectNode | AddNode | UpdateDeclaration
 
 export interface InitProject {
   type: 'InitProject'
@@ -30,4 +30,10 @@ export interface AddNode {
   currentUri: string
   nodeUri: string
   path: number[]
+}
+
+export interface UpdateDeclaration {
+  type: 'UpdateDeclaration'
+  uri: string
+  declaration: DeclarationUpdater
 }

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -79,6 +79,8 @@ export function wsEventObserver(
             return emit('selectNode', payload)
           case 'AddNode':
             return emit('addNode', payload)
+          case 'UpdateDeclaration':
+            return emit('updateDeclaration', payload)
           default:
             throw new Error(
               'Unexpected client payload: ' + (payload as any).type

--- a/src/view/components/PageMain.vue
+++ b/src/view/components/PageMain.vue
@@ -20,7 +20,11 @@
         <div v-else class="style-information">
           <p class="style-information-title">Node Styles</p>
           <div class="style-information-list">
-            <StyleInformation v-if="matchedRules.length > 0" :rules="matchedRules" />
+            <StyleInformation
+              v-if="matchedRules.length > 0"
+              :rules="matchedRules"
+              @update-declaration="updateDeclaration"
+            />
             <p class="not-found" v-else>Not found</p>
           </div>
         </div>
@@ -94,7 +98,8 @@ export default Vue.extend({
     'endDragging',
     'setDraggingPlace',
     'select',
-    'applyDraggingElement'
+    'applyDraggingElement',
+    'updateDeclaration'
   ])
 })
 </script>

--- a/src/view/components/StyleInformation.vue
+++ b/src/view/components/StyleInformation.vue
@@ -7,7 +7,11 @@
 
       <ul class="declaration-list">
         <li class="declaration" v-for="d in rule.declarations" :key="d.path.join('.')">
-          <span class="declaration-prop"><span class="declaration-prop-text">{{ d.prop }}</span></span>
+          <span class="declaration-prop"><StyleValue
+            class="declaration-prop-text"
+            :value="d.prop"
+            @input="inputStyleProp(d.path, arguments[0])"
+          /></span>
           <StyleValue
             :value="getStyleValue(d)"
             @input="inputStyleValue(d.path, arguments[0])"
@@ -38,6 +42,13 @@ export default Vue.extend({
   },
 
   methods: {
+    inputStyleProp(path: number[], prop: string): void {
+      this.$emit('update-declaration', {
+        path,
+        prop
+      })
+    },
+
     getStyleValue(declaration: Declaration): string {
       const important = declaration.important ? ' !important' : ''
       return declaration.value + important

--- a/src/view/components/StyleInformation.vue
+++ b/src/view/components/StyleInformation.vue
@@ -8,8 +8,10 @@
       <ul class="declaration-list">
         <li class="declaration" v-for="d in rule.declarations" :key="d.path.join('.')">
           <span class="declaration-prop"><span class="declaration-prop-text">{{ d.prop }}</span></span>
-          <span class="declaration-value">{{ d.value }}</span>
-          <span v-if="d.important" class="declaration-important">!important</span>
+          <StyleValue
+            :value="getStyleValue(d)"
+            @input="inputStyleValue(d.path, arguments[0])"
+          />
         </li>
       </ul>
     </li>
@@ -18,15 +20,44 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { RuleForPrint } from '@/parser/style/types'
+import StyleValue from './StyleValue.vue'
+import { RuleForPrint, Declaration } from '@/parser/style/types'
 
 export default Vue.extend({
   name: 'StyleInformation',
+
+  components: {
+    StyleValue
+  },
 
   props: {
     rules: {
       type: Array as () => RuleForPrint[],
       required: true
+    }
+  },
+
+  methods: {
+    getStyleValue(declaration: Declaration): string {
+      const important = declaration.important ? ' !important' : ''
+      return declaration.value + important
+    },
+
+    inputStyleValue(path: number[], value: string): void {
+      const match = /^\s*(.*)\s+!important\s*$/.exec(value)
+      if (match) {
+        this.$emit('update-declaration', {
+          path,
+          value: match[1],
+          important: true
+        })
+      } else {
+        this.$emit('update-declaration', {
+          path,
+          value: value.trim(),
+          important: false
+        })
+      }
     }
   }
 })

--- a/src/view/components/StyleInformation.vue
+++ b/src/view/components/StyleInformation.vue
@@ -13,7 +13,7 @@
             @input="inputStyleProp(d.path, arguments[0])"
           /></span>
           <StyleValue
-            :value="getStyleValue(d)"
+            :value="d.value"
             @input="inputStyleValue(d.path, arguments[0])"
           />
         </li>
@@ -25,7 +25,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import StyleValue from './StyleValue.vue'
-import { RuleForPrint, Declaration } from '@/parser/style/types'
+import { RuleForPrint } from '@/parser/style/types'
 
 export default Vue.extend({
   name: 'StyleInformation',
@@ -45,30 +45,15 @@ export default Vue.extend({
     inputStyleProp(path: number[], prop: string): void {
       this.$emit('update-declaration', {
         path,
-        prop
+        prop: prop.trim()
       })
     },
 
-    getStyleValue(declaration: Declaration): string {
-      const important = declaration.important ? ' !important' : ''
-      return declaration.value + important
-    },
-
     inputStyleValue(path: number[], value: string): void {
-      const match = /^\s*(.*)\s+!important\s*$/.exec(value)
-      if (match) {
-        this.$emit('update-declaration', {
-          path,
-          value: match[1],
-          important: true
-        })
-      } else {
-        this.$emit('update-declaration', {
-          path,
-          value: value.trim(),
-          important: false
-        })
-      }
+      this.$emit('update-declaration', {
+        path,
+        value: value.trim()
+      })
     }
   }
 })

--- a/src/view/components/StyleValue.vue
+++ b/src/view/components/StyleValue.vue
@@ -1,0 +1,71 @@
+<template>
+  <button
+    v-if="!editing"
+    class="style-value"
+    @click="startEdit"
+    @focus="startEdit"
+  >{{ value }}</button>
+  <div
+    v-else
+    class="style-value editing"
+    contenteditable="true"
+    ref="input"
+    @input="input"
+    @blur="endEdit"
+  >{{ value }}</div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'StyleValue',
+
+  props: {
+    value: {
+      type: String,
+      required: true
+    }
+  },
+
+  data() {
+    return {
+      editing: false
+    }
+  },
+
+  methods: {
+    startEdit() {
+      this.editing = true
+      this.$nextTick(() => {
+        ;(this.$refs.input as HTMLDivElement).focus()
+      })
+    },
+
+    endEdit() {
+      this.editing = false
+    },
+
+    input(event: Event) {
+      const el = event.target as HTMLDivElement
+      this.$emit('input', el.textContent)
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.style-value {
+  display: inline;
+  padding: 0;
+  border-width: 0;
+  background: none;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.style-value.editing {
+  margin: -1px;
+  border: 1px solid #aaa;
+}
+</style>

--- a/src/view/components/StyleValue.vue
+++ b/src/view/components/StyleValue.vue
@@ -13,7 +13,7 @@
     @input="input"
     @keypress.enter="endEdit"
     @blur="endEdit"
-  >{{ value }}</div>
+  ></div>
 </template>
 
 <script lang="ts">
@@ -35,19 +35,30 @@ export default Vue.extend({
     }
   },
 
+  watch: {
+    value(newValue: string): void {
+      const input = this.$refs.input as HTMLDivElement | undefined
+      if (input && newValue !== input.textContent) {
+        input.textContent = newValue
+      }
+    }
+  },
+
   methods: {
-    startEdit() {
+    startEdit(): void {
       this.editing = true
       this.$nextTick(() => {
-        ;(this.$refs.input as HTMLDivElement).focus()
+        const input = this.$refs.input as HTMLDivElement
+        input.textContent = this.value
+        input.focus()
       })
     },
 
-    endEdit() {
+    endEdit(): void {
       this.editing = false
     },
 
-    input(event: Event) {
+    input(event: Event): void {
       const el = event.target as HTMLDivElement
       this.$emit('input', el.textContent)
     }

--- a/src/view/components/StyleValue.vue
+++ b/src/view/components/StyleValue.vue
@@ -11,6 +11,7 @@
     contenteditable="true"
     ref="input"
     @input="input"
+    @keypress.enter="endEdit"
     @blur="endEdit"
   >{{ value }}</div>
 </template>

--- a/src/view/components/StyleValue.vue
+++ b/src/view/components/StyleValue.vue
@@ -49,9 +49,11 @@ export default Vue.extend({
     startEdit(): void {
       this.editing = true
       this.$nextTick(() => {
-        const input = this.$refs.input as HTMLDivElement
-        input.textContent = this.value
-        selectNodeContents(input)
+        const input = this.$refs.input as HTMLDivElement | undefined
+        if (input) {
+          input.textContent = this.value
+          selectNodeContents(input)
+        }
       })
     },
 

--- a/src/view/components/StyleValue.vue
+++ b/src/view/components/StyleValue.vue
@@ -18,6 +18,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { selectNodeContents } from '@/view/editing'
 
 export default Vue.extend({
   name: 'StyleValue',
@@ -50,7 +51,7 @@ export default Vue.extend({
       this.$nextTick(() => {
         const input = this.$refs.input as HTMLDivElement
         input.textContent = this.value
-        input.focus()
+        selectNodeContents(input)
       })
     },
 

--- a/src/view/components/StyleValue.vue
+++ b/src/view/components/StyleValue.vue
@@ -68,5 +68,7 @@ export default Vue.extend({
 .style-value.editing {
   margin: -1px;
   border: 1px solid #aaa;
+  background-color: #fff;
+  outline: none;
 }
 </style>

--- a/src/view/editing.ts
+++ b/src/view/editing.ts
@@ -1,0 +1,10 @@
+export function selectNodeContents(el: Node): void {
+  // Skip if selection does not exist (in case of testing environment)
+  if (!('getSelection' in window)) return
+
+  const selection = window.getSelection()
+  const range = new Range()
+  range.selectNodeContents(el)
+  selection.removeAllRanges()
+  selection.addRange(range)
+}

--- a/src/view/store/modules/project.ts
+++ b/src/view/store/modules/project.ts
@@ -7,7 +7,7 @@ import {
   insertNode,
   getNode
 } from '@/parser/template/manipulate'
-import { RuleForPrint } from '@/parser/style/types'
+import { RuleForPrint, DeclarationUpdater } from '@/parser/style/types'
 import { addScope as addScopeToStyle } from '@/parser/style/manipulate'
 import { genStyle } from '@/parser/style/codegen'
 import { Prop, Data, ChildComponent } from '@/parser/script/types'
@@ -51,6 +51,7 @@ interface ProjectActions {
   startDragging: string
   endDragging: undefined
   setDraggingPlace: { path: number[]; place: DraggingPlace }
+  updateDeclaration: DeclarationUpdater
 }
 
 interface ProjectMutations {
@@ -326,6 +327,16 @@ export const project: DefineModule<
           commit('setDraggingPath', insertInto)
         }
       }, draggingInterval)
+    },
+
+    updateDeclaration({ state }, payload) {
+      if (!state.currentUri) return
+
+      connection.send({
+        type: 'UpdateDeclaration',
+        uri: state.currentUri,
+        declaration: payload
+      })
     }
   },
 

--- a/src/view/store/modules/project.ts
+++ b/src/view/store/modules/project.ts
@@ -8,11 +8,7 @@ import {
   insertNode,
   getNode
 } from '@/parser/template/manipulate'
-import {
-  RuleForPrint,
-  DeclarationUpdater,
-  DeclarationForPrint
-} from '@/parser/style/types'
+import { RuleForPrint, DeclarationUpdater } from '@/parser/style/types'
 import { addScope as addScopeToStyle } from '@/parser/style/manipulate'
 import { genStyle } from '@/parser/style/codegen'
 import { Prop, Data, ChildComponent } from '@/parser/script/types'

--- a/test/parser/style-helpers.ts
+++ b/test/parser/style-helpers.ts
@@ -15,6 +15,7 @@ import {
 export function createStyle(body: (AtRule | Rule)[]): Style {
   modifyPath(body)
   return {
+    path: [0],
     body,
     range: [-1, -1]
   }
@@ -32,7 +33,7 @@ function modifyPath(nodes: (AtRule | Rule | Declaration)[]): void {
       }
     })
   }
-  loop(nodes, [])
+  loop(nodes, [0])
 }
 
 export function atRule(

--- a/test/view/StyleValue/basic.spec.ts
+++ b/test/view/StyleValue/basic.spec.ts
@@ -42,7 +42,7 @@ describe('StyleValue basic', () => {
     expect(wrapper.emitted('input')[0]).toEqual(['22px'])
   })
 
-  it('should cancel editing when blured', () => {
+  it('should end editing when blured', () => {
     const wrapper = mount(StyleValue, {
       propsData: {
         value: '20px'
@@ -52,6 +52,21 @@ describe('StyleValue basic', () => {
     expect(wrapper.attributes()!.contenteditable).toBe('true')
 
     wrapper.trigger('blur')
+    expect(wrapper.attributes()!.contenteditable).not.toBe('true')
+  })
+
+  it('should end editing when pushed enter', () => {
+    const wrapper = mount(StyleValue, {
+      propsData: {
+        value: '20px'
+      }
+    })
+    wrapper.trigger('click')
+    expect(wrapper.attributes()!.contenteditable).toBe('true')
+
+    wrapper.trigger('keypress', {
+      keyCode: 13
+    })
     expect(wrapper.attributes()!.contenteditable).not.toBe('true')
   })
 })

--- a/test/view/StyleValue/basic.spec.ts
+++ b/test/view/StyleValue/basic.spec.ts
@@ -1,0 +1,57 @@
+import StyleValue from '@/view/components/StyleValue.vue'
+import { mount } from '@vue/test-utils'
+
+describe('StyleValue basic', () => {
+  it('should render', () => {
+    const wrapper = mount(StyleValue, {
+      propsData: {
+        value: '20px'
+      }
+    })
+    expect(wrapper.attributes()!.contenteditable).not.toBe('true')
+    expect(wrapper.text()).toBe('20px')
+  })
+
+  it('should make editable when clicked', () => {
+    const wrapper = mount(StyleValue, {
+      propsData: {
+        value: '20px'
+      }
+    })
+    wrapper.trigger('click')
+    expect(wrapper.attributes()!.contenteditable).toBe('true')
+
+    const el = wrapper.find('[contenteditable]')
+    el.element.textContent = '22px'
+    el.trigger('input')
+    expect(wrapper.emitted('input')[0]).toEqual(['22px'])
+  })
+
+  it('should make editable when focused', () => {
+    const wrapper = mount(StyleValue, {
+      propsData: {
+        value: '20px'
+      }
+    })
+    wrapper.trigger('focus')
+    expect(wrapper.attributes()!.contenteditable).toBe('true')
+
+    const el = wrapper.find('[contenteditable]')
+    el.element.textContent = '22px'
+    el.trigger('input')
+    expect(wrapper.emitted('input')[0]).toEqual(['22px'])
+  })
+
+  it('should cancel editing when blured', () => {
+    const wrapper = mount(StyleValue, {
+      propsData: {
+        value: '20px'
+      }
+    })
+    wrapper.trigger('click')
+    expect(wrapper.attributes()!.contenteditable).toBe('true')
+
+    wrapper.trigger('blur')
+    expect(wrapper.attributes()!.contenteditable).not.toBe('true')
+  })
+})

--- a/test/view/StyleValue/basic.spec.ts
+++ b/test/view/StyleValue/basic.spec.ts
@@ -12,14 +12,17 @@ describe('StyleValue basic', () => {
     expect(wrapper.text()).toBe('20px')
   })
 
-  it('should make editable when clicked', () => {
+  it('should make editable when clicked', async () => {
     const wrapper = mount(StyleValue, {
       propsData: {
         value: '20px'
       }
     })
     wrapper.trigger('click')
+    await wrapper.vm.$nextTick()
+
     expect(wrapper.attributes()!.contenteditable).toBe('true')
+    expect(wrapper.text()).toBe('20px')
 
     const el = wrapper.find('[contenteditable]')
     el.element.textContent = '22px'
@@ -27,14 +30,17 @@ describe('StyleValue basic', () => {
     expect(wrapper.emitted('input')[0]).toEqual(['22px'])
   })
 
-  it('should make editable when focused', () => {
+  it('should make editable when focused', async () => {
     const wrapper = mount(StyleValue, {
       propsData: {
         value: '20px'
       }
     })
     wrapper.trigger('focus')
+    await wrapper.vm.$nextTick()
+
     expect(wrapper.attributes()!.contenteditable).toBe('true')
+    expect(wrapper.text()).toBe('20px')
 
     const el = wrapper.find('[contenteditable]')
     el.element.textContent = '22px'
@@ -68,5 +74,24 @@ describe('StyleValue basic', () => {
       keyCode: 13
     })
     expect(wrapper.attributes()!.contenteditable).not.toBe('true')
+  })
+
+  it('should update editing content when prop is updated', async () => {
+    const wrapper = mount(StyleValue, {
+      propsData: {
+        value: 'red'
+      }
+    })
+    wrapper.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.attributes()!.contenteditable).toBe('true')
+    expect(wrapper.text()).toBe('red')
+
+    wrapper.setProps({
+      value: 'blue'
+    })
+    expect(wrapper.attributes()!.contenteditable).toBe('true')
+    expect(wrapper.text()).toBe('blue')
   })
 })


### PR DESCRIPTION
This feature allows us to edit styles in the preview pane like chrome devtools but it immediately update the original code in SFC.

I'll add more test and support renaming declaration prop later.

Adding declaration is not supported yet.
![editable-style](https://user-images.githubusercontent.com/2194624/37267261-6a9d9014-2602-11e8-842b-a0ff8d7bec85.gif)
