### PR TITLE
fix: match selected node and style rules in client side

### DIFF
--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -1,11 +1,12 @@
-import { RuleForPrint, DeclarationUpdater } from '../parser/style/types'
+import { DeclarationUpdater } from '../parser/style/types'
 import { VueFilePayload } from '../parser/vue-file'
 
 export interface Events {
   initClient: undefined
   selectNode: {
     uri: string
-    path: number[]
+    templatePath: number[]
+    stylePaths: number[][]
   }
   addNode: {
     currentUri: string
@@ -35,7 +36,6 @@ export interface Events {
 export interface Commands {
   initProject: Record<string, VueFilePayload>
   changeDocument: string
-  matchRules: RuleForPrint[]
   highlightEditor: {
     uri: string
     ranges: [number, number][]

--- a/src/parser/style/manipulate.ts
+++ b/src/parser/style/manipulate.ts
@@ -44,11 +44,11 @@ export function addScope(node: t.Style, scope: string): t.Style {
   })
 }
 
-export function getDeclaration(
+export function getNode(
   styles: t.Style[],
   path: number[]
-): t.Declaration | undefined {
-  const res = path.reduce<any | undefined>(
+): t.ChildNode | undefined {
+  return path.reduce<any | undefined>(
     (acc, i) => {
       if (!acc) return
 
@@ -62,6 +62,12 @@ export function getDeclaration(
     },
     { children: styles }
   )
+}
 
+export function getDeclaration(
+  styles: t.Style[],
+  path: number[]
+): t.Declaration | undefined {
+  const res = getNode(styles, path)
   return res && res.type === 'Declaration' ? res : undefined
 }

--- a/src/parser/vue-file.ts
+++ b/src/parser/vue-file.ts
@@ -14,9 +14,8 @@ import {
   extractProps,
   extractData
 } from './script/manipulate'
-import { Style, Rule } from './style/types'
+import { Style } from './style/types'
 import { transformStyle } from './style/transform'
-import { createStyleMatcher } from './style/match'
 
 export interface VueFilePayload {
   uri: string
@@ -38,7 +37,6 @@ export interface VueFile {
   data: Data[]
   childComponents: ChildComponent[]
   styles: Style[]
-  matchSelector: (template: Template, targetPath: number[]) => Rule[]
 }
 
 export function parseVueFile(code: string, uri: string): VueFile {
@@ -75,8 +73,7 @@ export function parseVueFile(code: string, uri: string): VueFile {
     props: extractProps(scriptBody),
     data: extractData(scriptBody),
     childComponents,
-    styles: styleAsts,
-    matchSelector: createStyleMatcher(styleAsts)
+    styles: styleAsts
   }
 }
 

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -1,7 +1,7 @@
 import { VueFilePayload } from './parser/vue-file'
-import { RuleForPrint, DeclarationUpdater } from './parser/style/types'
+import { DeclarationUpdater } from './parser/style/types'
 
-export type ServerPayload = InitProject | ChangeDocument | MatchRules
+export type ServerPayload = InitProject | ChangeDocument
 export type ClientPayload = SelectNode | AddNode | UpdateDeclaration
 
 export interface InitProject {
@@ -14,15 +14,11 @@ export interface ChangeDocument {
   uri: string
 }
 
-export interface MatchRules {
-  type: 'MatchRules'
-  rules: RuleForPrint[]
-}
-
 export interface SelectNode {
   type: 'SelectNode'
   uri: string
-  path: number[]
+  templatePath: number[]
+  stylePaths: number[][]
 }
 
 export interface AddNode {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -109,9 +109,5 @@ export function wsCommandEmiter(
     observe('changeDocument', payload => {
       send({ type: 'ChangeDocument', uri: payload })
     })
-
-    observe('matchRules', payload => {
-      send({ type: 'MatchRules', rules: payload })
-    })
   })
 }

--- a/src/view/store/index.ts
+++ b/src/view/store/index.ts
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import { Store, install as vuexInstall } from 'vuex'
 import modules from './modules'
 import { ClientConnection } from '../communication'
+import { StyleMatcher } from './style-matcher'
 
 Vue.use(vuexInstall)
 
@@ -10,8 +11,12 @@ export const store = new Store({
 })
 
 const connection = new ClientConnection()
+const styleMatcher = new StyleMatcher()
 connection.connect(location.port)
-store.dispatch('project/init', connection)
+store.dispatch('project/init', {
+  connection,
+  styleMatcher
+})
 
 declare const module: any
 if (module.hot) {

--- a/src/view/store/style-matcher.ts
+++ b/src/view/store/style-matcher.ts
@@ -1,0 +1,30 @@
+import { Style, Rule } from '@/parser/style/types'
+import { Template } from '@/parser/template/types'
+import { createStyleMatcher } from '@/parser/style/match'
+
+type Matcher = (template: Template, path: number[]) => Rule[]
+
+export class StyleMatcher {
+  private matchers = new Map<string, Matcher>()
+
+  match(uri: string, template: Template, path: number[]): Rule[] {
+    const matcher = this.matchers.get(uri)
+    if (!matcher) {
+      return []
+    }
+    return matcher(template, path)
+  }
+
+  register(uri: string, styles: Style[]): void {
+    const matcher = createStyleMatcher(styles)
+    this.matchers.set(uri, matcher)
+  }
+
+  unregister(uri: string): void {
+    this.matchers.delete(uri)
+  }
+
+  clear(): void {
+    this.matchers.clear()
+  }
+}

--- a/test/view/store/project.spec.ts
+++ b/test/view/store/project.spec.ts
@@ -196,7 +196,9 @@ describe('Store project actions', () => {
       send: jest.fn(),
       onMessage: jest.fn()
     } as any
-    store.dispatch('project/init', mockConnection)
+    store.dispatch('project/init', {
+      connection: mockConnection
+    })
   })
 
   describe('updateDeclaration', () => {

--- a/test/view/store/style-matcher.spec.ts
+++ b/test/view/store/style-matcher.spec.ts
@@ -1,0 +1,81 @@
+import { createStyle, rule, selector } from '../../parser/style-helpers'
+import { StyleMatcher } from '@/view/store/style-matcher'
+import { createTemplate, h, a } from '../../parser/template-helpers'
+
+describe('StyleMatcher', () => {
+  it('should match specified uri styles', () => {
+    const style1 = createStyle([rule([selector({ tag: 'p' })])])
+    const style2 = createStyle([rule([selector({ class: ['foo'] })])])
+
+    const matcher = new StyleMatcher()
+    matcher.register('file:///test1.vue', [style1])
+    matcher.register('file:///test2.vue', [style2])
+
+    const actual = matcher.match(
+      'file:///test1.vue',
+      createTemplate([h('p', [a('class', 'foo')], [])]),
+      [0]
+    )
+    expect(actual.length).toBe(1)
+    expect(actual[0].selectors[0].tag).toBe('p')
+  })
+
+  it('should ignore if styles are not registered with uri', () => {
+    const matcher = new StyleMatcher()
+    const actual = matcher.match(
+      'file:///test1.vue',
+      createTemplate([h('p', [a('class', 'foo')], [])]),
+      [0]
+    )
+    expect(actual.length).toBe(0)
+  })
+
+  it('should unregister styles from matcher', () => {
+    const style = createStyle([rule([selector({ tag: 'p' })])])
+
+    const matcher = new StyleMatcher()
+    matcher.register('file:///test1.vue', [style])
+
+    let actual = matcher.match(
+      'file:///test1.vue',
+      createTemplate([h('p', [a('class', 'foo')], [])]),
+      [0]
+    )
+    expect(actual.length).toBe(1)
+    expect(actual[0].selectors[0].tag).toBe('p')
+
+    matcher.unregister('file:///test1.vue')
+
+    actual = matcher.match(
+      'file:///test1.vue',
+      createTemplate([h('p', [a('class', 'foo')], [])]),
+      [0]
+    )
+    expect(actual.length).toBe(0)
+  })
+
+  it('should clear all styles', () => {
+    const style1 = createStyle([rule([selector({ tag: 'p' })])])
+    const style2 = createStyle([rule([selector({ class: ['foo'] })])])
+
+    const matcher = new StyleMatcher()
+    matcher.register('file:///test1.vue', [style1])
+    matcher.register('file:///test2.vue', [style2])
+
+    matcher.clear()
+
+    const actual1 = matcher.match(
+      'file:///test1.vue',
+      createTemplate([h('p', [a('class', 'foo')], [])]),
+      [0]
+    )
+    const actual2 = matcher.match(
+      'file:///test2.vue',
+      createTemplate([h('p', [a('class', 'foo')], [])]),
+      [0]
+    )
+
+    expect(actual1.length).toBe(0)
+    expect(actual2.length).toBe(0)
+  })
+})


### PR DESCRIPTION
This fixes #7 

In this PR, I've moved style matcher from server side to client side so that we immediately calculate the selected node's styles. Also we can react the changes of any styles in editor to update the preview pane's styles.