### PR TITLE
fix: avoid to make input caret jump during editing declaration

### DIFF
--- a/src/view/components/StyleInformation.vue
+++ b/src/view/components/StyleInformation.vue
@@ -49,17 +49,17 @@ export default Vue.extend({
   },
 
   methods: {
-    inputStyleProp(path: number[], rawProp: string): void {
+    inputStyleProp(path: number[], prop: string): void {
       this.$emit('update-declaration', {
         path,
-        prop: rawProp.trim()
+        prop
       })
     },
 
-    inputStyleValue(path: number[], rawValue: string): void {
+    inputStyleValue(path: number[], value: string): void {
       this.$emit('update-declaration', {
         path,
-        value: rawValue.trim()
+        value
       })
     },
 
@@ -69,6 +69,8 @@ export default Vue.extend({
         this.$emit('remove-declaration', {
           path
         })
+      } else {
+        this.inputStyleProp(path, prop)
       }
     },
 
@@ -78,6 +80,8 @@ export default Vue.extend({
         this.$emit('remove-declaration', {
           path
         })
+      } else {
+        this.inputStyleValue(path, value)
       }
     },
 


### PR DESCRIPTION
In case if the users remove the part of declaration value, then it is trimmable like `10px 2` -> `10px `, the caret will be jumped even though she is editing the value. It would decrease the UX of style editing.

This is caused because the current implementation always trims the updated text. So I've stopped trimming the value on `input` event. Instead, trim it when the `input-end` event so that the problem should not be occurred during user editing.