### PR TITLE
fix: avoid clashing by ECONNRESET

### DIFF
--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -91,6 +91,13 @@ export function wsEventObserver(
             )
         }
       })
+
+      ws.on('error', err => {
+        // To avoid clashing extension by ECONNRESET error...
+        // https://github.com/websockets/ws/issues/1256
+        if ((err as any).code === 'ECONNRESET') return
+        throw err
+      })
     })
   })
 }


### PR DESCRIPTION
fix #23 

The problem caused by ECONNRESET error of WebSocket connection. When the user move to another tab and hide the preview tab, the preview page will be destroyed. Then the socket emit ECONNRESET error.

Looks like the WebSocket error will be automatically throws if we do not register any error event listener and it causes this problem. So I added an event listener that ignores only ECONNRESET error.

Note `err.code` is valid property of Node.js Error object. https://nodejs.org/api/errors.html#errors_error_code_1