### PR TITLE
fix: normalize scale delta during various environments

### DIFF
--- a/src/view/components/Viewport.vue
+++ b/src/view/components/Viewport.vue
@@ -21,6 +21,7 @@
 import Vue from 'vue'
 import GlobalEvents from 'vue-global-events'
 import Resizable from './Resizable.vue'
+import { minmax } from '@/utils'
 
 export default Vue.extend({
   name: 'Viewport',
@@ -55,7 +56,8 @@ export default Vue.extend({
 
   methods: {
     onZoom(event: WheelEvent): void {
-      this.$emit('zoom', this.scale - event.deltaY * 0.01)
+      const normalized = minmax(-0.1, event.deltaY * 0.01, 0.1)
+      this.$emit('zoom', this.scale - normalized)
     }
   }
 })


### PR DESCRIPTION
fix #26 

I realized we already can scroll with <kbd>Shift</kbd> + scroll and zoom with <kbd>Ctrl</kbd> + scroll. So I would keep this behavior as official keyboard shortcut.

But there are some inconsistency of `deltaY` on WheelEvent during various environments. e.g. Windows + mouse provides too large value for `deltaY`. So I have normalized it not to change scale too much by one wheel event.