### PR TITLE
ci: fix failing test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "watch:ts": "tsc --watch -p tsconfig.main.json",
     "watch:webpack": "webpack-dev-server --hot --config webpack.config.js --mode development",
     "build": "tsc --sourceMap false -p tsconfig.main.json && webpack --config webpack.config.js --mode production",
-    "test": "jest",
+    "test": "jest -w 2",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage -w 2",
     "format": "prettier --write \"{src,test}/**/*.{ts,vue}\""


### PR DESCRIPTION
The CI error looks the same problem with I encountered before in coverage test. So I just added max workers option of jest as same as coverage script.