### PR TITLE
refactor: migrate store lib from vuex to sinai

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13651,6 +13651,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/sinai/-/sinai-0.2.2.tgz",
       "integrity": "sha512-0NqdSZq9dFa5TGEiGHMzlEM7P8Df7FKTM0rDKelDGHzzTm2hlWyR0BWtCBGf+1rXKwHZp+a/4e1uZeX2dVK+rw==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.2"
       }
@@ -15423,7 +15424,8 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13647,6 +13647,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "sinai": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/sinai/-/sinai-0.2.2.tgz",
+      "integrity": "sha512-0NqdSZq9dFa5TGEiGHMzlEM7P8Df7FKTM0rDKelDGHzzTm2hlWyR0BWtCBGf+1rXKwHZp+a/4e1uZeX2dVK+rw==",
+      "requires": {
+        "tslib": "^1.9.2"
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -15412,6 +15420,11 @@
         "strip-json-comments": "^2.0.0"
       }
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -16105,11 +16118,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
       "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==",
-      "dev": true
-    },
-    "vuex": {
-      "version": "github:ktsn/vuex#fc1f29bdba1ea49264c9d5a369f50fbdb636ac67",
-      "from": "github:ktsn/vuex#fc1f29b",
       "dev": true
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "postcss": "^6.0.22",
     "postcss-safe-parser": "^3.0.1",
     "postcss-selector-parser": "^5.0.0-rc.3",
-    "sinai": "^0.2.2",
     "vue-eslint-parser": "^2.0.3",
     "vue-template-compiler": "^2.5.16",
     "ws": "^5.2.0"
@@ -116,6 +115,7 @@
     "raw-loader": "^0.5.1",
     "rimraf": "^2.6.2",
     "sass-loader": "^7.0.2",
+    "sinai": "^0.2.2",
     "testdouble": "^3.8.1",
     "ts-jest": "^22.4.6",
     "ts-loader": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -56,9 +56,12 @@
   },
   "jest": {
     "transform": {
-      "^.+\\.ts$": "ts-jest",
+      "^.+\\.[jt]s$": "ts-jest",
       "^.+\\.vue$": "vue-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(sinai/lib)/)"
+    ],
     "setupFiles": [
       "<rootDir>/test/setup.ts"
     ],
@@ -91,6 +94,7 @@
     "postcss": "^6.0.22",
     "postcss-safe-parser": "^3.0.1",
     "postcss-selector-parser": "^5.0.0-rc.3",
+    "sinai": "^0.2.2",
     "vue-eslint-parser": "^2.0.3",
     "vue-template-compiler": "^2.5.16",
     "ws": "^5.2.0"
@@ -123,7 +127,6 @@
     "vue-loader": "^15.2.4",
     "vue-server-renderer": "^2.5.16",
     "vue-style-loader": "^4.1.0",
-    "vuex": "github:ktsn/vuex#fc1f29b",
     "webpack": "^4.10.2",
     "webpack-cli": "^3.0.1",
     "webpack-dev-server": "^3.1.4",

--- a/src/view/components/ContainerNode.vue
+++ b/src/view/components/ContainerNode.vue
@@ -12,7 +12,9 @@ import Vue from 'vue'
 import Node from './Node.vue'
 import { Element } from '@/parser/template/types'
 import { DefaultValue, ChildComponent } from '@/parser/script/types'
-import { projectHelpers } from '../store/modules/project'
+import { mapper } from '../store'
+
+const projectMapper = mapper.module('project')
 
 export default Vue.extend({
   name: 'ContainerNode',
@@ -44,7 +46,7 @@ export default Vue.extend({
   },
 
   computed: {
-    ...projectHelpers.mapState(['selectedPath', 'currentUri']),
+    ...projectMapper.mapState(['selectedPath', 'currentUri']),
 
     selected(): boolean {
       const path = this.data.path

--- a/src/view/components/ContainerVueComponent.vue
+++ b/src/view/components/ContainerVueComponent.vue
@@ -13,11 +13,10 @@
 <script lang="ts">
 import Vue from 'vue'
 import VueComponent from './VueComponent.vue'
-import {
-  ScopedDocument,
-  projectHelpers,
-  DocumentScope
-} from '../store/modules/project'
+import { ScopedDocument, DocumentScope } from '../store/modules/project'
+import { mapper } from '../store'
+
+const projectMapper = mapper.module('project')
 
 export default Vue.extend({
   name: 'ContainerVueComponent',
@@ -39,11 +38,11 @@ export default Vue.extend({
   },
 
   computed: {
-    ...projectHelpers.mapState({
+    ...projectMapper.mapState({
       scopes: 'documentScopes'
     }),
 
-    ...projectHelpers.mapGetters({
+    ...projectMapper.mapGetters({
       documents: 'scopedDocuments'
     }),
 

--- a/src/view/components/PageMain.vue
+++ b/src/view/components/PageMain.vue
@@ -86,8 +86,11 @@ import ScopeInformation from './ScopeInformation.vue'
 import StyleInformation from './StyleInformation.vue'
 import ComponentCatalog from './ComponentCatalog.vue'
 import Toolbar from './Toolbar.vue'
-import { projectHelpers, ScopedDocument } from '../store/modules/project'
-import { viewportHelpers } from '@/view/store/modules/viewport'
+import { ScopedDocument } from '../store/modules/project'
+import { mapper } from '../store'
+
+const projectMapper = mapper.module('project')
+const viewportMapper = mapper.module('viewport')
 
 export default Vue.extend({
   name: 'PageMain',
@@ -107,15 +110,15 @@ export default Vue.extend({
   },
 
   computed: {
-    ...projectHelpers.mapState({
+    ...projectMapper.mapState({
       uri: 'currentUri',
       selectedPath: 'selectedPath',
       matchedRules: 'matchedRules'
     }),
 
-    ...viewportHelpers.mapState(['width', 'height', 'scale']),
+    ...viewportMapper.mapState(['width', 'height', 'scale']),
 
-    ...projectHelpers.mapGetters({
+    ...projectMapper.mapGetters({
       document: 'currentDocument',
       scope: 'currentScope',
       renderingDocument: 'currentRenderingDocument',
@@ -130,7 +133,7 @@ export default Vue.extend({
   },
 
   methods: {
-    ...projectHelpers.mapActions([
+    ...projectMapper.mapActions([
       'startDragging',
       'endDragging',
       'setDraggingPlace',
@@ -141,9 +144,9 @@ export default Vue.extend({
       'updateDeclaration'
     ]),
 
-    ...projectHelpers.mapMutations(['updatePropValue', 'updateDataValue']),
+    ...projectMapper.mapMutations(['updatePropValue', 'updateDataValue']),
 
-    ...viewportHelpers.mapActions(['resize', 'zoom']),
+    ...viewportMapper.mapActions(['resize', 'zoom']),
 
     onStartDragging(uri: string): void {
       // Deselect to avoid showing incorrect bounds

--- a/src/view/store/index.ts
+++ b/src/view/store/index.ts
@@ -1,19 +1,20 @@
 import Vue from 'vue'
-import { Store, install as vuexInstall } from 'vuex'
-import modules from './modules'
+import { store as createStore, install, createMapper } from 'sinai'
+import rootModule from './modules'
 import { ClientConnection } from '../communication'
 import { StyleMatcher } from './style-matcher'
 
-Vue.use(vuexInstall)
+Vue.use(install)
 
-export const store = new Store({
-  modules
+export const store = createStore(rootModule, {
+  strict: process.env.NODE_ENV !== 'production'
 })
+export const mapper = createMapper<typeof store>()
 
 const connection = new ClientConnection()
 const styleMatcher = new StyleMatcher()
 connection.connect(location.port)
-store.dispatch('project/init', {
+store.actions.project.init({
   connection,
   styleMatcher
 })
@@ -21,9 +22,7 @@ store.dispatch('project/init', {
 declare const module: any
 if (module.hot) {
   module.hot.accept(['./modules'], () => {
-    const newModules = require('./modules').default
-    store.hotUpdate({
-      modules: newModules
-    })
+    const newRootModule = require('./modules').default
+    store.hotUpdate(newRootModule)
   })
 }

--- a/src/view/store/modules/index.ts
+++ b/src/view/store/modules/index.ts
@@ -1,7 +1,7 @@
+import { module } from 'sinai'
 import { project } from './project'
 import { viewport } from './viewport'
 
-export default {
-  project,
-  viewport
-}
+export default module()
+  .child('project', project)
+  .child('viewport', viewport)

--- a/src/view/store/modules/project.ts
+++ b/src/view/store/modules/project.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import Vue from 'vue'
-import { DefineModule, createNamespacedHelpers } from 'vuex'
+import { Getters, Mutations, Actions, module } from 'sinai'
 import { VueFilePayload } from '@/parser/vue-file'
 import { Template, Element } from '@/parser/template/types'
 import {
@@ -39,553 +39,510 @@ export interface DocumentScope {
 
 export type DraggingPlace = 'before' | 'after' | 'first' | 'last'
 
-export interface ProjectState {
-  documents: Record<string, VueFilePayload>
-  documentScopes: Record<string, DocumentScope>
-  currentUri: string | undefined
-  draggingUri: string | undefined
-  selectedPath: number[]
-  draggingPath: number[]
-  matchedRules: RuleForPrint[]
-}
-
-interface ProjectGetters {
-  scopedDocuments: Record<string, ScopedDocument>
-  currentDocument: VueFilePayload | undefined
-  currentScope: DocumentScope | undefined
-  currentRenderingDocument: ScopedDocument | undefined
-  draggingScopedDocument: ScopedDocument | undefined
-  localNameOfDragging: string | undefined
-  nodeOfDragging: Element | undefined
-}
-
-interface ProjectActions {
-  init: {
-    connection: ClientConnection
-    styleMatcher: StyleMatcher
-  }
-  select: Element | undefined
-  applyDraggingElement: undefined
-  startDragging: string
-  endDragging: undefined
-  setDraggingPlace: { path: number[]; place: DraggingPlace }
-  addDeclaration: {
-    path: number[]
-  }
-  removeDeclaration: {
-    path: number[]
-  }
-  updateDeclaration: {
-    path: number[]
-    prop?: string
-    value?: string
-  }
-  matchSelectedNodeWithStyles: undefined
-}
-
-interface ProjectMutations {
-  setDocuments: Record<string, VueFilePayload>
-  changeDocument: string
-  select: number[]
-  addElement: { path: number[]; node: Element }
-  addChildComponent: ChildComponent
-  setDraggingUri: string | undefined
-  setDraggingPath: number[]
-  setMatchedRules: RuleForPrint[]
-
-  // TODO: add removeScope mutation after splitting
-  // document update notification into more grained
-  refreshScope: {
-    uri: string
-    props: Prop[]
-    data: Data[]
-  }
-  updatePropValue: {
-    name: string
-    value: any
-  }
-  updateDataValue: {
-    name: string
-    value: any
-  }
-}
-
-export const projectHelpers = createNamespacedHelpers<
-  ProjectState,
-  ProjectGetters,
-  ProjectMutations,
-  ProjectActions
->('project')
-
 let connection: ClientConnection
 let styleMatcher: StyleMatcher
 let draggingTimer: any
 const draggingInterval = 80
 
-export const project: DefineModule<
-  ProjectState,
-  ProjectGetters,
-  ProjectMutations,
-  ProjectActions
-> = {
-  namespaced: true,
+export class ProjectState {
+  documents: Record<string, VueFilePayload> = {}
+  documentScopes: Record<string, DocumentScope> = {}
+  currentUri: string | undefined = undefined
+  draggingUri: string | undefined = undefined
+  selectedPath: number[] = []
+  draggingPath: number[] = []
+  matchedRules: RuleForPrint[] = []
+}
 
-  state: () => ({
-    documents: {},
-    documentScopes: {},
-    currentUri: undefined,
-    draggingUri: undefined,
-    selectedPath: [],
-    draggingPath: [],
-    matchedRules: []
-  }),
-
-  getters: {
-    scopedDocuments(state) {
-      return mapValues(state.documents, doc => {
-        const pathEls = doc.uri.split('/')
-        const displayName = pathEls[pathEls.length - 1].replace(/\..*$/, '')
-
-        return {
-          uri: doc.uri,
-          displayName,
-          template:
-            doc.template && addScopeToTemplate(doc.template, doc.scopeId),
-          props: doc.props,
-          data: doc.data,
-          childComponents: doc.childComponents,
-          styleCode: doc.styles
-            .reduce<string[]>((acc, style) => {
-              return acc.concat(genStyle(addScopeToStyle(style, doc.scopeId)))
-            }, [])
-            .join('\n')
-        }
-      })
-    },
-
-    currentDocument(state) {
-      if (!state.currentUri) {
-        return undefined
-      }
-      return state.documents[state.currentUri]
-    },
-
-    currentScope(state) {
-      if (!state.currentUri) {
-        return undefined
-      }
-      return state.documentScopes[state.currentUri]
-    },
-
-    currentRenderingDocument(state, getters) {
-      if (!state.currentUri) {
-        return undefined
-      }
-
-      const doc = getters.scopedDocuments[state.currentUri]
-      if (!doc) {
-        return undefined
-      }
-
-      const dragging = getters.draggingScopedDocument
-      const insertInto = state.draggingPath
-      const newNode = getters.nodeOfDragging
-      if (!doc.template || !dragging || insertInto.length === 0 || !newNode) {
-        return doc
-      }
-
-      const newChildComponents = getters.localNameOfDragging
-        ? doc.childComponents
-        : doc.childComponents.concat({
-            name: dragging.displayName,
-            uri: dragging.uri
-          })
+export class ProjectGetters extends Getters<ProjectState>() {
+  get scopedDocuments(): Record<string, ScopedDocument> {
+    const { state } = this
+    return mapValues(state.documents, doc => {
+      const pathEls = doc.uri.split('/')
+      const displayName = pathEls[pathEls.length - 1].replace(/\..*$/, '')
 
       return {
-        ...doc,
-        childComponents: newChildComponents,
-        template: insertNode(doc.template, insertInto, newNode)
+        uri: doc.uri,
+        displayName,
+        template: doc.template && addScopeToTemplate(doc.template, doc.scopeId),
+        props: doc.props,
+        data: doc.data,
+        childComponents: doc.childComponents,
+        styleCode: doc.styles
+          .reduce<string[]>((acc, style) => {
+            return acc.concat(genStyle(addScopeToStyle(style, doc.scopeId)))
+          }, [])
+          .join('\n')
       }
-    },
+    })
+  }
 
-    draggingScopedDocument(state, getters) {
-      return state.draggingUri
-        ? getters.scopedDocuments[state.draggingUri]
-        : undefined
-    },
+  get currentDocument(): VueFilePayload | undefined {
+    const { state } = this
+    if (!state.currentUri) {
+      return undefined
+    }
+    return state.documents[state.currentUri]
+  }
 
-    localNameOfDragging(state, getters) {
-      const doc = state.currentUri && getters.scopedDocuments[state.currentUri]
-      const dragging = getters.draggingScopedDocument
+  get currentScope(): DocumentScope | undefined {
+    const { state } = this
+    if (!state.currentUri) {
+      return undefined
+    }
+    return state.documentScopes[state.currentUri]
+  }
 
-      if (!doc || !dragging) {
-        return undefined
+  get currentRenderingDocument(): ScopedDocument | undefined {
+    const { state } = this
+    if (!state.currentUri) {
+      return undefined
+    }
+
+    const doc = this.scopedDocuments[state.currentUri]
+    if (!doc) {
+      return undefined
+    }
+
+    const dragging = this.draggingScopedDocument
+    const insertInto = state.draggingPath
+    const newNode = this.nodeOfDragging
+    if (!doc.template || !dragging || insertInto.length === 0 || !newNode) {
+      return doc
+    }
+
+    const newChildComponents = this.localNameOfDragging
+      ? doc.childComponents
+      : doc.childComponents.concat({
+          name: dragging.displayName,
+          uri: dragging.uri
+        })
+
+    return {
+      ...doc,
+      childComponents: newChildComponents,
+      template: insertNode(doc.template, insertInto, newNode)
+    }
+  }
+
+  get draggingScopedDocument(): ScopedDocument | undefined {
+    const { state } = this
+    return state.draggingUri
+      ? this.scopedDocuments[state.draggingUri]
+      : undefined
+  }
+
+  get localNameOfDragging(): string | undefined {
+    const { state } = this
+    const doc = state.currentUri && this.scopedDocuments[state.currentUri]
+    const dragging = this.draggingScopedDocument
+
+    if (!doc || !dragging) {
+      return undefined
+    }
+
+    return doc.childComponents.reduce<string | undefined>((acc, comp) => {
+      if (acc) return acc
+
+      if (comp.uri === dragging.uri) {
+        return comp.name
       }
+    }, undefined)
+  }
 
-      return doc.childComponents.reduce<string | undefined>((acc, comp) => {
-        if (acc) return acc
+  get nodeOfDragging(): Element | undefined {
+    const dragging = this.draggingScopedDocument
+    if (!dragging) {
+      return
+    }
 
-        if (comp.uri === dragging.uri) {
-          return comp.name
-        }
-      }, undefined)
-    },
-
-    nodeOfDragging(_state, getters) {
-      const dragging = getters.draggingScopedDocument
-      if (!dragging) {
-        return
-      }
-
-      const localName = getters.localNameOfDragging
-      return {
-        type: 'Element',
-        path: [],
-        name: localName || dragging.displayName,
-        startTag: {
-          type: 'StartTag',
-          attributes: [],
-          selfClosing: false,
-          range: [-1, -1]
-        },
-        endTag: {
-          type: 'EndTag',
-          range: [-1, -1]
-        },
-        children: [],
+    const localName = this.localNameOfDragging
+    return {
+      type: 'Element',
+      path: [],
+      name: localName || dragging.displayName,
+      startTag: {
+        type: 'StartTag',
+        attributes: [],
+        selfClosing: false,
         range: [-1, -1]
-      }
-    }
-  },
-
-  actions: {
-    init({ commit, dispatch }, payload) {
-      connection = payload.connection
-      styleMatcher = payload.styleMatcher
-
-      connection.onMessage(data => {
-        switch (data.type) {
-          case 'InitProject':
-            commit('setDocuments', data.vueFiles)
-            styleMatcher.clear()
-            Object.keys(data.vueFiles).forEach(key => {
-              const file = data.vueFiles[key]
-              styleMatcher.register(file.uri, file.styles)
-
-              commit('refreshScope', {
-                uri: key,
-                props: file.props,
-                data: file.data
-              })
-            })
-            dispatch('matchSelectedNodeWithStyles', undefined)
-            break
-          case 'ChangeDocument':
-            commit('changeDocument', data.uri)
-            break
-          default: // Do nothing
-        }
-      })
-    },
-
-    select({ commit, dispatch, getters, state }, node) {
-      const current = getters.currentDocument
-      if (!current) return
-
-      const path = node ? node.path : []
-
-      commit('select', path)
-      dispatch('matchSelectedNodeWithStyles', undefined).then(() => {
-        connection.send({
-          type: 'SelectNode',
-          uri: current.uri,
-          templatePath: path,
-          stylePaths: state.matchedRules.map(r => r.path)
-        })
-      })
-    },
-
-    applyDraggingElement({ commit, state, getters }) {
-      const currentUri = state.currentUri
-      const nodeUri = state.draggingUri
-      const path = state.draggingPath
-      const newNode = getters.nodeOfDragging
-
-      if (!currentUri || !nodeUri || path.length === 0 || !newNode) {
-        return
-      }
-
-      connection.send({
-        type: 'AddNode',
-        path,
-        currentUri,
-        nodeUri
-      })
-
-      commit('addElement', {
-        path,
-        node: newNode
-      })
-
-      const localName = getters.localNameOfDragging
-      if (!localName) {
-        commit('addChildComponent', {
-          name: newNode.name,
-          uri: state.draggingUri!
-        })
-      }
-    },
-
-    startDragging({ commit }, uri) {
-      commit('setDraggingUri', uri)
-    },
-
-    endDragging({ commit }) {
-      commit('setDraggingUri', undefined)
-      commit('setDraggingPath', [])
-    },
-
-    setDraggingPlace({ state, getters, commit }, { path, place }) {
-      clearTimeout(draggingTimer)
-      draggingTimer = setTimeout(() => {
-        const doc = getters.currentDocument
-        if (!doc || !doc.template) {
-          return
-        }
-
-        const node = getNode(doc.template, path)
-        if (!node) {
-          return
-        }
-
-        let insertInto: number[]
-        if (place === 'before') {
-          insertInto = node.path
-        } else if (place === 'after') {
-          const last = node.path[node.path.length - 1]
-          insertInto = node.path.slice(0, -1).concat(last + 1)
-        } else if (place === 'first') {
-          const el = node as Element
-          assert(
-            el.type === 'Element',
-            `[store/project] node type must be 'Element' when place is 'first' but received '${
-              node.type
-            }'`
-          )
-          insertInto = el.path.concat(0)
-        } else {
-          const el = node as Element
-          assert(
-            el.type === 'Element',
-            `[store/project] node type must be 'Element' when place is 'last' but received '${
-              node.type
-            }'`
-          )
-          const len = el.children.length
-          insertInto = el.path.concat(len)
-        }
-
-        const isUpdated =
-          state.draggingPath.length !== insertInto.length ||
-          path.reduce((acc, el, i) => {
-            return acc || state.draggingPath[i] !== el
-          }, false)
-
-        if (isUpdated) {
-          commit('setDraggingPath', insertInto)
-        }
-      }, draggingInterval)
-    },
-
-    addDeclaration({ state }, { path }) {
-      if (!state.currentUri) return
-
-      connection.send({
-        type: 'AddDeclaration',
-        uri: state.currentUri,
-        path,
-        declaration: {
-          // Currently, write the placeholder value to simplify the implementation.
-          prop: 'property',
-          value: 'value',
-          important: false
-        }
-      })
-    },
-
-    removeDeclaration({ state }, { path }) {
-      if (!state.currentUri) return
-
-      connection.send({
-        type: 'RemoveDeclaration',
-        uri: state.currentUri,
-        path
-      })
-    },
-
-    updateDeclaration({ state }, payload) {
-      if (!state.currentUri) return
-
-      const updater: DeclarationForUpdate = {
-        path: payload.path
-      }
-
-      // This check does not pass if prop (and value) is an empty string.
-      // It is intentional since the css parser will go unexpected state
-      // if we update them to empty value.
-      if (payload.prop) {
-        updater.prop = payload.prop
-      }
-
-      if (payload.value) {
-        const match = /^\s*(.*)\s+!important\s*$/.exec(payload.value)
-        if (match) {
-          updater.value = match[1]
-          updater.important = true
-        } else {
-          updater.value = payload.value
-          updater.important = false
-        }
-      }
-
-      connection.send({
-        type: 'UpdateDeclaration',
-        uri: state.currentUri,
-        declaration: updater
-      })
-    },
-
-    matchSelectedNodeWithStyles({ commit, getters, state }) {
-      const doc = getters.currentDocument
-      const selected = state.selectedPath
-
-      if (!doc || !doc.template || selected.length === 0) {
-        commit('setMatchedRules', [])
-        return
-      }
-
-      const matchedRules = styleMatcher.match(doc.uri, doc.template, selected)
-      const forPrint = matchedRules.map(transformRuleForPrint)
-
-      commit('setMatchedRules', forPrint)
-    }
-  },
-
-  mutations: {
-    setDocuments(state, vueFiles) {
-      state.documents = vueFiles
-    },
-
-    changeDocument(state, uri) {
-      if (state.currentUri !== uri) {
-        state.currentUri = uri
-        state.selectedPath = []
-        state.matchedRules = []
-      }
-    },
-
-    select(state, path) {
-      state.selectedPath = path
-      state.matchedRules = []
-    },
-
-    addElement(state, { path, node }) {
-      const uri = state.currentUri
-      if (uri) {
-        const doc = state.documents[uri]
-        if (doc && doc.template) {
-          doc.template = insertNode(doc.template, path, node)
-        }
-      }
-    },
-
-    addChildComponent(state, childComponent) {
-      const uri = state.currentUri
-      if (uri) {
-        const doc = state.documents[uri]
-        if (doc) {
-          doc.childComponents = doc.childComponents.concat(childComponent)
-        }
-      }
-    },
-
-    setDraggingUri(state, uri) {
-      state.draggingUri = uri
-    },
-
-    setDraggingPath(state, path) {
-      state.draggingPath = path
-    },
-
-    setMatchedRules(state, rules) {
-      state.matchedRules = rules
-    },
-
-    // TODO: move this logic to server side
-    refreshScope(state, { uri, props, data }) {
-      function update(
-        scope: Record<string, DocumentScopeItem>,
-        next: (Prop | Data)[]
-      ): void {
-        const willRemove = Object.keys(scope)
-
-        next.forEach(item => {
-          if (!scope[item.name]) {
-            Vue.set(scope, item.name, {
-              type: null,
-              value: item.default
-            })
-          }
-
-          scope[item.name].type = 'type' in item ? item.type : null
-
-          const index = willRemove.indexOf(item.name)
-          if (index >= 0) {
-            willRemove.splice(index, 1)
-          }
-        })
-
-        willRemove.forEach(key => {
-          Vue.delete(scope, key)
-        })
-      }
-
-      let scope = state.documentScopes[uri]
-      if (!scope) {
-        scope = Vue.set(state.documentScopes, uri, {
-          props: {},
-          data: {}
-        })
-      }
-
-      update(scope.props, props)
-      update(scope.data, data)
-    },
-
-    updatePropValue(state, { name, value }) {
-      const uri = state.currentUri
-      if (!uri) return
-
-      const scope = state.documentScopes[uri]
-      if (!scope) return
-
-      const target = scope.props[name]
-      if (!target) return
-
-      target.value = value
-    },
-
-    updateDataValue(state, { name, value }) {
-      const uri = state.currentUri
-      if (!uri) return
-
-      const scope = state.documentScopes[uri]
-      if (!scope) return
-
-      const target = scope.data[name]
-      if (!target) return
-
-      target.value = value
+      },
+      endTag: {
+        type: 'EndTag',
+        range: [-1, -1]
+      },
+      children: [],
+      range: [-1, -1]
     }
   }
 }
+
+export class ProjectMutations extends Mutations<ProjectState>() {
+  setDocuments(vueFiles: Record<string, VueFilePayload>): void {
+    this.state.documents = vueFiles
+  }
+
+  changeDocument(uri: string): void {
+    const { state } = this
+    if (state.currentUri !== uri) {
+      state.currentUri = uri
+      state.selectedPath = []
+      state.matchedRules = []
+    }
+  }
+
+  select(path: number[]): void {
+    const { state } = this
+    state.selectedPath = path
+    state.matchedRules = []
+  }
+
+  addElement({ path, node }: { path: number[]; node: Element }): void {
+    const { state } = this
+    const uri = state.currentUri
+    if (uri) {
+      const doc = state.documents[uri]
+      if (doc && doc.template) {
+        doc.template = insertNode(doc.template, path, node)
+      }
+    }
+  }
+
+  addChildComponent(childComponent: ChildComponent): void {
+    const { state } = this
+    const uri = state.currentUri
+    if (uri) {
+      const doc = state.documents[uri]
+      if (doc) {
+        doc.childComponents = doc.childComponents.concat(childComponent)
+      }
+    }
+  }
+
+  setDraggingUri(uri: string | undefined): void {
+    this.state.draggingUri = uri
+  }
+
+  setDraggingPath(path: number[]): void {
+    this.state.draggingPath = path
+  }
+
+  setMatchedRules(rules: RuleForPrint[]): void {
+    this.state.matchedRules = rules
+  }
+
+  // TODO: move this logic to server side
+  refreshScope({
+    uri,
+    props,
+    data
+  }: {
+    uri: string
+    props: Prop[]
+    data: Data[]
+  }) {
+    function update(
+      scope: Record<string, DocumentScopeItem>,
+      next: (Prop | Data)[]
+    ): void {
+      const willRemove = Object.keys(scope)
+
+      next.forEach(item => {
+        if (!scope[item.name]) {
+          Vue.set(scope, item.name, {
+            type: null,
+            value: item.default
+          })
+        }
+
+        scope[item.name].type = 'type' in item ? item.type : null
+
+        const index = willRemove.indexOf(item.name)
+        if (index >= 0) {
+          willRemove.splice(index, 1)
+        }
+      })
+
+      willRemove.forEach(key => {
+        Vue.delete(scope, key)
+      })
+    }
+
+    let scope = this.state.documentScopes[uri]
+    if (!scope) {
+      scope = Vue.set(this.state.documentScopes, uri, {
+        props: {},
+        data: {}
+      })
+    }
+
+    update(scope.props, props)
+    update(scope.data, data)
+  }
+
+  updatePropValue({ name, value }: { name: string; value: any }): void {
+    const uri = this.state.currentUri
+    if (!uri) return
+
+    const scope = this.state.documentScopes[uri]
+    if (!scope) return
+
+    const target = scope.props[name]
+    if (!target) return
+
+    target.value = value
+  }
+
+  updateDataValue({ name, value }: { name: string; value: any }): void {
+    const uri = this.state.currentUri
+    if (!uri) return
+
+    const scope = this.state.documentScopes[uri]
+    if (!scope) return
+
+    const target = scope.data[name]
+    if (!target) return
+
+    target.value = value
+  }
+}
+
+export class ProjectActions extends Actions<
+  ProjectState,
+  ProjectGetters,
+  ProjectMutations
+>() {
+  init(payload: {
+    connection: ClientConnection
+    styleMatcher: StyleMatcher
+  }): void {
+    connection = payload.connection
+    styleMatcher = payload.styleMatcher
+
+    connection.onMessage(data => {
+      switch (data.type) {
+        case 'InitProject':
+          this.mutations.setDocuments(data.vueFiles)
+          styleMatcher.clear()
+          Object.keys(data.vueFiles).forEach(key => {
+            const file = data.vueFiles[key]
+            styleMatcher.register(file.uri, file.styles)
+
+            this.mutations.refreshScope({
+              uri: key,
+              props: file.props,
+              data: file.data
+            })
+          })
+          this.matchSelectedNodeWithStyles()
+          break
+        case 'ChangeDocument':
+          this.mutations.changeDocument(data.uri)
+          break
+        default: // Do nothing
+      }
+    })
+  }
+
+  select(node: Element | undefined): void {
+    const { state, getters, mutations } = this
+    const current = getters.currentDocument
+    if (!current) return
+
+    const path = node ? node.path : []
+
+    mutations.select(path)
+    this.matchSelectedNodeWithStyles()
+
+    connection.send({
+      type: 'SelectNode',
+      uri: current.uri,
+      templatePath: path,
+      stylePaths: state.matchedRules.map(r => r.path)
+    })
+  }
+
+  applyDraggingElement(): void {
+    const { state, getters, mutations } = this
+    const currentUri = state.currentUri
+    const nodeUri = state.draggingUri
+    const path = state.draggingPath
+    const newNode = getters.nodeOfDragging
+
+    if (!currentUri || !nodeUri || path.length === 0 || !newNode) {
+      return
+    }
+
+    connection.send({
+      type: 'AddNode',
+      path,
+      currentUri,
+      nodeUri
+    })
+
+    mutations.addElement({
+      path,
+      node: newNode
+    })
+
+    const localName = getters.localNameOfDragging
+    if (!localName) {
+      mutations.addChildComponent({
+        name: newNode.name,
+        uri: state.draggingUri!
+      })
+    }
+  }
+
+  startDragging(uri: string): void {
+    this.mutations.setDraggingUri(uri)
+  }
+
+  endDragging(): void {
+    const { setDraggingUri, setDraggingPath } = this.mutations
+    setDraggingUri(undefined)
+    setDraggingPath([])
+  }
+
+  setDraggingPlace({
+    path,
+    place
+  }: {
+    path: number[]
+    place: DraggingPlace
+  }): void {
+    clearTimeout(draggingTimer)
+    draggingTimer = setTimeout(() => {
+      const doc = this.getters.currentDocument
+      if (!doc || !doc.template) {
+        return
+      }
+
+      const node = getNode(doc.template, path)
+      if (!node) {
+        return
+      }
+
+      let insertInto: number[]
+      if (place === 'before') {
+        insertInto = node.path
+      } else if (place === 'after') {
+        const last = node.path[node.path.length - 1]
+        insertInto = node.path.slice(0, -1).concat(last + 1)
+      } else if (place === 'first') {
+        const el = node as Element
+        assert(
+          el.type === 'Element',
+          `[store/project] node type must be 'Element' when place is 'first' but received '${
+            node.type
+          }'`
+        )
+        insertInto = el.path.concat(0)
+      } else {
+        const el = node as Element
+        assert(
+          el.type === 'Element',
+          `[store/project] node type must be 'Element' when place is 'last' but received '${
+            node.type
+          }'`
+        )
+        const len = el.children.length
+        insertInto = el.path.concat(len)
+      }
+
+      const isUpdated =
+        this.state.draggingPath.length !== insertInto.length ||
+        path.reduce((acc, el, i) => {
+          return acc || this.state.draggingPath[i] !== el
+        }, false)
+
+      if (isUpdated) {
+        this.mutations.setDraggingPath(insertInto)
+      }
+    }, draggingInterval)
+  }
+
+  addDeclaration({ path }: { path: number[] }): void {
+    if (!this.state.currentUri) return
+
+    connection.send({
+      type: 'AddDeclaration',
+      uri: this.state.currentUri,
+      path,
+      declaration: {
+        // Currently, write the placeholder value to simplify the implementation.
+        prop: 'property',
+        value: 'value',
+        important: false
+      }
+    })
+  }
+
+  removeDeclaration({ path }: { path: number[] }): void {
+    if (!this.state.currentUri) return
+
+    connection.send({
+      type: 'RemoveDeclaration',
+      uri: this.state.currentUri,
+      path
+    })
+  }
+
+  updateDeclaration(payload: {
+    path: number[]
+    prop: string
+    value: string
+  }): void {
+    if (!this.state.currentUri) return
+
+    const updater: DeclarationForUpdate = {
+      path: payload.path
+    }
+
+    // This check does not pass if prop (and value) is an empty string.
+    // It is intentional since the css parser will go unexpected state
+    // if we update them to empty value.
+    if (payload.prop) {
+      updater.prop = payload.prop
+    }
+
+    if (payload.value) {
+      const match = /^\s*(.*)\s+!important\s*$/.exec(payload.value)
+      if (match) {
+        updater.value = match[1]
+        updater.important = true
+      } else {
+        updater.value = payload.value
+        updater.important = false
+      }
+    }
+
+    connection.send({
+      type: 'UpdateDeclaration',
+      uri: this.state.currentUri,
+      declaration: updater
+    })
+  }
+
+  matchSelectedNodeWithStyles(): void {
+    const doc = this.getters.currentDocument
+    const selected = this.state.selectedPath
+
+    if (!doc || !doc.template || selected.length === 0) {
+      this.mutations.setMatchedRules([])
+      return
+    }
+
+    const matchedRules = styleMatcher.match(doc.uri, doc.template, selected)
+    const forPrint = matchedRules.map(transformRuleForPrint)
+
+    this.mutations.setMatchedRules(forPrint)
+  }
+}
+
+export const project = module({
+  state: ProjectState,
+  getters: ProjectGetters,
+  mutations: ProjectMutations,
+  actions: ProjectActions
+})

--- a/src/view/store/modules/viewport.ts
+++ b/src/view/store/modules/viewport.ts
@@ -1,70 +1,40 @@
-import { DefineModule, createNamespacedHelpers } from 'vuex'
+import { Mutations, Actions, module } from 'sinai'
 import { minmax } from '@/utils'
 
-interface ViewportState {
-  width: number
-  height: number
-  scale: number
+class ViewportState {
+  width = 600
+  height = 800
+  scale = 1.0
 }
 
-interface ViewportActions {
-  resize: {
-    width: number
-    height: number
+class ViewportMutations extends Mutations<ViewportState>() {
+  resize({ width, height }: { width: number; height: number }): void {
+    const min = 10
+    const { state } = this
+    state.width = Math.max(min, Math.floor(width))
+    state.height = Math.max(min, Math.floor(height))
   }
-  zoom: number
-}
 
-interface ViewportMutations {
-  resize: {
-    width: number
-    height: number
-  }
-  zoom: number
-}
-
-export const viewportHelpers = createNamespacedHelpers<
-  ViewportState,
-  {},
-  ViewportMutations,
-  ViewportActions
->('viewport')
-
-export const viewport: DefineModule<
-  ViewportState,
-  {},
-  ViewportMutations,
-  ViewportActions
-> = {
-  namespaced: true,
-
-  state: () => ({
-    width: 600,
-    height: 800,
-    scale: 1.0
-  }),
-
-  actions: {
-    resize({ commit }, payload) {
-      commit('resize', payload)
-    },
-
-    zoom({ commit }, payload) {
-      commit('zoom', payload)
-    }
-  },
-
-  mutations: {
-    resize(state, { width, height }) {
-      const min = 10
-      state.width = Math.max(min, Math.floor(width))
-      state.height = Math.max(min, Math.floor(height))
-    },
-
-    zoom(state, scale) {
-      const max = 5
-      const min = 0.1
-      state.scale = minmax(min, scale, max)
-    }
+  zoom(scale: number) {
+    const max = 5
+    const min = 0.1
+    const { state } = this
+    state.scale = minmax(min, scale, max)
   }
 }
+
+class ViewportActions extends Actions<ViewportState, ViewportMutations>() {
+  resize(payload: { width: number; height: number }): void {
+    this.mutations.resize(payload)
+  }
+
+  zoom(payload: number): void {
+    this.mutations.zoom(payload)
+  }
+}
+
+export const viewport = module({
+  state: ViewportState,
+  mutations: ViewportMutations,
+  actions: ViewportActions
+})

--- a/test/helpers/template.ts
+++ b/test/helpers/template.ts
@@ -1,4 +1,4 @@
-import { Store } from 'vuex'
+import { store as createStore, module } from 'sinai'
 import { mount, Wrapper } from '@vue/test-utils'
 import {
   Template,
@@ -13,7 +13,7 @@ import {
 import { Prop, Data, ChildComponent } from '@/parser/script/types'
 import { VueFilePayload } from '@/parser/vue-file'
 import VueComponent from '@/view/components/VueComponent.vue'
-import { project as originalProject } from '@/view/store/modules/project'
+import { project } from '@/view/store/modules/project'
 import { mapValues } from '@/utils'
 
 export function render(
@@ -23,19 +23,16 @@ export function render(
   childComponents: ChildComponent[] = [],
   storeDocuments: Record<string, Partial<VueFilePayload>> = {}
 ): Wrapper<VueComponent> {
-  const store = new Store({
-    modules: { project: originalProject }
-  })
+  const store = createStore(module().child('project', project))
 
-  store.commit('project/changeDocument', 'file:///Test.vue')
-  store.commit('project/refreshScope', {
+  store.mutations.project.changeDocument('file:///Test.vue')
+  store.mutations.project.refreshScope({
     uri: 'file:///Test.vue',
     props,
     data
   })
 
-  store.commit(
-    'project/setDocuments',
+  store.mutations.project.setDocuments(
     mapValues(storeDocuments, (doc, uri) => {
       return {
         uri,
@@ -51,7 +48,7 @@ export function render(
 
   Object.keys(storeDocuments).forEach(uri => {
     const doc = storeDocuments[uri]
-    store.commit('project/refreshScope', {
+    store.mutations.project.refreshScope({
       uri,
       props: doc.props || [],
       data: doc.data || []
@@ -62,7 +59,7 @@ export function render(
     propsData: {
       uri: 'file:///Test.vue',
       template,
-      scope: store.getters['project/currentScope'],
+      scope: store.getters.project.currentScope,
       childComponents,
       styles: ''
     },

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { install } from 'vuex'
+import { install } from 'sinai'
 
 Vue.config.productionTip = false
 Vue.config.devtools = false


### PR DESCRIPTION
This PR replaces the store library from [Vuex](https://github.com/vuejs/vuex) to [Sinai](https://github.com/ktsn/sinai). 

Sadly Vuex's interface is hard to be type checked, especially when we want the modules to communicate each other. I'm developing Sinai as an alternative approach to ensure type safety and it has the same concept with Vuex - the store parts are separated as modules and they are constructed by state, getters, actions and mutations. It also supports vue-devtools inspection by mimicking Vuex.