### PR TITLE
feat: allow to include shared styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,17 @@
     "onCommand:extension.openVueDesigner"
   ],
   "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "Vue Designer configuration",
+      "properties": {
+        "vueDesigner.sharedStyles": {
+          "type": "array",
+          "default": [],
+          "description": "Path to css files which will be loaded globally in the preview"
+        }
+      }
+    },
     "commands": [
       {
         "command": "extension.openVueDesigner",

--- a/src/message/bus.ts
+++ b/src/message/bus.ts
@@ -26,6 +26,7 @@ export function observeServerEvents(
   activeUri: string | undefined
 ): void {
   let lastActiveUri: string | undefined = activeUri
+  let sharedStyle: string = ''
 
   const vueFileToPayload = (vueFile: VueFile) => {
     return _vueFileToPayload(vueFile, assetResolver)
@@ -33,9 +34,15 @@ export function observeServerEvents(
 
   bus.on('initClient', () => {
     bus.emit('initProject', mapValues(vueFiles, vueFileToPayload))
+    bus.emit('initSharedStyle', sharedStyle)
     if (lastActiveUri) {
       bus.emit('changeDocument', lastActiveUri)
     }
+  })
+
+  bus.on('loadSharedStyle', style => {
+    sharedStyle = style
+    bus.emit('initSharedStyle', style)
   })
 
   bus.on('selectNode', payload => {

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -3,6 +3,7 @@ import { VueFilePayload } from '../parser/vue-file'
 
 export interface Events {
   initClient: undefined
+  loadSharedStyle: string
   selectNode: {
     uri: string
     templatePath: number[]
@@ -44,6 +45,7 @@ export interface Events {
 
 export interface Commands {
   initProject: Record<string, VueFilePayload>
+  initSharedStyle: string
   changeDocument: string
   highlightEditor: {
     uri: string

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -1,7 +1,7 @@
 import { VueFilePayload } from './parser/vue-file'
 import { DeclarationForUpdate, DeclarationForAdd } from './parser/style/types'
 
-export type ServerPayload = InitProject | ChangeDocument
+export type ServerPayload = InitProject | InitSharedStyle | ChangeDocument
 export type ClientPayload =
   | SelectNode
   | AddNode
@@ -12,6 +12,11 @@ export type ClientPayload =
 export interface InitProject {
   type: 'InitProject'
   vueFiles: Record<string, VueFilePayload>
+}
+
+export interface InitSharedStyle {
+  type: 'InitSharedStyle'
+  style: string
 }
 
 export interface ChangeDocument {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -133,6 +133,10 @@ export function wsCommandEmiter(
       send({ type: 'InitProject', vueFiles: payload })
     })
 
+    observe('initSharedStyle', payload => {
+      send({ type: 'InitSharedStyle', style: payload })
+    })
+
     observe('changeDocument', payload => {
       send({ type: 'ChangeDocument', uri: payload })
     })

--- a/src/view/store/modules/project/project-actions.ts
+++ b/src/view/store/modules/project/project-actions.ts
@@ -45,6 +45,9 @@ export class ProjectActions extends Actions<
           })
           this.matchSelectedNodeWithStyles()
           break
+        case 'InitSharedStyle':
+          this.mutations.setSharedStyle(data.style)
+          break
         case 'ChangeDocument':
           this.mutations.changeDocument(data.uri)
           break

--- a/src/view/store/modules/project/project-getters.ts
+++ b/src/view/store/modules/project/project-getters.ts
@@ -18,6 +18,11 @@ export class ProjectGetters extends Getters<ProjectState>() {
       const pathEls = doc.uri.split('/')
       const displayName = pathEls[pathEls.length - 1].replace(/\..*$/, '')
 
+      const styleCodes = doc.styles.reduce<string[]>((acc, style) => {
+        return acc.concat(genStyle(addScopeToStyle(style, doc.scopeId)))
+      }, [])
+      styleCodes.unshift(this.state.sharedStyle)
+
       return {
         uri: doc.uri,
         displayName,
@@ -25,11 +30,7 @@ export class ProjectGetters extends Getters<ProjectState>() {
         props: doc.props,
         data: doc.data,
         childComponents: doc.childComponents,
-        styleCode: doc.styles
-          .reduce<string[]>((acc, style) => {
-            return acc.concat(genStyle(addScopeToStyle(style, doc.scopeId)))
-          }, [])
-          .join('\n')
+        styleCode: styleCodes.join('\n')
       }
     })
   }

--- a/src/view/store/modules/project/project-mutations.ts
+++ b/src/view/store/modules/project/project-mutations.ts
@@ -50,6 +50,10 @@ export class ProjectMutations extends Mutations<ProjectState>() {
     }
   }
 
+  setSharedStyle(style: string): void {
+    this.state.sharedStyle = style
+  }
+
   setDraggingUri(uri: string | undefined): void {
     this.state.draggingUri = uri
   }

--- a/src/view/store/modules/project/project-state.ts
+++ b/src/view/store/modules/project/project-state.ts
@@ -5,6 +5,7 @@ import { DocumentScope } from './types'
 export class ProjectState {
   documents: Record<string, VueFilePayload> = {}
   documentScopes: Record<string, DocumentScope> = {}
+  sharedStyle = ''
   currentUri: string | undefined = undefined
   draggingUri: string | undefined = undefined
   selectedPath: number[] = []

--- a/test/view/store/project.spec.ts
+++ b/test/view/store/project.spec.ts
@@ -37,7 +37,18 @@ describe('Store project getters', () => {
         }
       })
       const actual = getters.scopedDocuments['file:///Foo.vue']
-      expect(actual.styleCode).toBe('div[data-scope-foo] {}')
+      expect(actual.styleCode).toBe('\ndiv[data-scope-foo] {}')
+    })
+
+    it('should add shared style to style code', () => {
+      const getters = stub(ProjectGetters, {
+        state: {
+          documents: documents(),
+          sharedStyle: 'h1 { margin: 0; }'
+        }
+      })
+      const actual = getters.scopedDocuments['file:///Foo.vue']
+      expect(actual.styleCode).toBe('h1 { margin: 0; }\ndiv[data-scope-foo] {}')
     })
   })
 


### PR DESCRIPTION
This PR let us to specify `vueDesigner.sharedStyles` config which allows to include global styles into the preview page.

It would be useful when we use some css frameworks, reset / normalize css or so on.

I guess I will update this PR to enable watching the changes for the shared styles so that update the preview style in realtime.

Currently, shared style affects globally not only user defined components but also app level (Vue Designer's) components. It should be avoided but seems the implementation will be a bit complicated. I would leave it as a further improvement.

The preprocessors are not supported as same as `<style>` block in SFC.