### PR TITLE
feat: render slot contents

### DIFF
--- a/src/view/components/Child.vue
+++ b/src/view/components/Child.vue
@@ -41,9 +41,11 @@ export default Vue.extend({
     const { data, scope } = props
     switch (data.type) {
       case 'Element':
+        const slot = data.startTag.attributes.find(attr => attr.name === 'slot')
         return h(data.name === 'slot' ? NodeSlot : ContainerNode, {
           props,
-          on: listeners
+          on: listeners,
+          slot: slot && slot.value
         })
       case 'TextNode':
         return [data.text]

--- a/src/view/components/Child.vue
+++ b/src/view/components/Child.vue
@@ -29,11 +29,15 @@ export default Vue.extend({
     childComponents: {
       type: Array as { (): ChildComponent[] },
       required: true
+    },
+
+    slots: {
+      type: Object as { (): Record<string, VNode[]> },
+      required: true
     }
   },
 
-  // @ts-ignore
-  render(h, { props, listeners }): VNode {
+  render(h, { props, listeners }): any /* VNode | VNode[] */ {
     const { data, scope } = props
     switch (data.type) {
       case 'Element':
@@ -42,7 +46,7 @@ export default Vue.extend({
           on: listeners
         })
       case 'TextNode':
-        return [data.text] as any
+        return [data.text]
       case 'ExpressionNode':
         return h(Expression, {
           props: {

--- a/src/view/components/Child.vue
+++ b/src/view/components/Child.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Vue, { VNode } from 'vue'
+import NodeSlot from './NodeSlot.vue'
 import ContainerNode from './ContainerNode.vue'
 import Expression from './Expression.vue'
 import { ElementChild } from '@/parser/template/types'
@@ -33,16 +34,11 @@ export default Vue.extend({
 
   // @ts-ignore
   render(h, { props, listeners }): VNode {
-    const { uri, data, scope, childComponents } = props
+    const { data, scope } = props
     switch (data.type) {
       case 'Element':
-        return h(ContainerNode, {
-          props: {
-            uri,
-            data,
-            scope,
-            childComponents
-          },
+        return h(data.name === 'slot' ? NodeSlot : ContainerNode, {
+          props,
           on: listeners
         })
       case 'TextNode':

--- a/src/view/components/ContainerNode.vue
+++ b/src/view/components/ContainerNode.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import Vue, { VNode } from 'vue'
 import Node from './Node.vue'
 import { Element } from '@/parser/template/types'
 import { DefaultValue, ChildComponent } from '@/parser/script/types'
@@ -41,6 +41,11 @@ export default Vue.extend({
 
     childComponents: {
       type: Array as { (): ChildComponent[] },
+      required: true
+    },
+
+    slots: {
+      type: Object as { (): Record<string, VNode[]> },
       required: true
     }
   },

--- a/src/view/components/ContainerVueComponent.vue
+++ b/src/view/components/ContainerVueComponent.vue
@@ -1,17 +1,5 @@
-<template>
-  <VueComponent
-    v-if="document"
-    :uri="uri"
-    :template="document.template"
-    :scope="scope"
-    :child-components="document.childComponents"
-    :styles="document.styleCode"
-    :props-data="propsData"
-  />
-</template>
-
 <script lang="ts">
-import Vue from 'vue'
+import Vue, { VNode } from 'vue'
 import VueComponent from './VueComponent.vue'
 import { ScopedDocument, DocumentScope } from '../store/modules/project/types'
 import { mapper } from '../store'
@@ -20,10 +8,6 @@ const projectMapper = mapper.module('project')
 
 export default Vue.extend({
   name: 'ContainerVueComponent',
-
-  beforeCreate() {
-    this.$options.components!.VueComponent = VueComponent
-  },
 
   props: {
     uri: {
@@ -52,7 +36,39 @@ export default Vue.extend({
 
     scope(): DocumentScope | undefined {
       return this.scopes[this.uri]
+    },
+
+    flattenSlots(): VNode[] {
+      const h = this.$createElement
+      return Object.keys(this.$slots).map(name => {
+        return h(
+          'template',
+          {
+            slot: name
+          },
+          this.$slots[name]
+        )
+      })
     }
+  },
+
+  render(h): VNode {
+    if (!this.document) return h()
+
+    return h(
+      VueComponent,
+      {
+        props: {
+          uri: this.uri,
+          template: this.document.template,
+          scope: this.scope,
+          childComponents: this.document.childComponents,
+          styles: this.document.styleCode,
+          propsData: this.propsData
+        }
+      },
+      this.flattenSlots
+    )
   }
 })
 </script>

--- a/src/view/components/ContainerVueComponent.vue
+++ b/src/view/components/ContainerVueComponent.vue
@@ -36,24 +36,21 @@ export default Vue.extend({
 
     scope(): DocumentScope | undefined {
       return this.scopes[this.uri]
-    },
-
-    flattenSlots(): VNode[] {
-      const h = this.$createElement
-      return Object.keys(this.$slots).map(name => {
-        return h(
-          'template',
-          {
-            slot: name
-          },
-          this.$slots[name]
-        )
-      })
     }
   },
 
   render(h): VNode {
     if (!this.document) return h()
+
+    const flattenSlots = Object.keys(this.$slots).map(name => {
+      return h(
+        'template',
+        {
+          slot: name
+        },
+        this.$slots[name]
+      )
+    })
 
     return h(
       VueComponent,
@@ -67,7 +64,7 @@ export default Vue.extend({
           propsData: this.propsData
         }
       },
-      this.flattenSlots
+      flattenSlots
     )
   }
 })

--- a/src/view/components/Node.vue
+++ b/src/view/components/Node.vue
@@ -31,6 +31,10 @@ export default Vue.extend({
       type: Array as { (): ChildComponent[] },
       required: true
     },
+    slots: {
+      type: Object as { (): Record<string, VNode[]> },
+      required: true
+    },
     selectable: Boolean,
     selected: Boolean
   },
@@ -152,7 +156,7 @@ export default Vue.extend({
   },
 
   render(h): VNode {
-    const { uri, childComponents } = this
+    const { uri, childComponents, slots } = this
 
     return h(
       this.vnodeTag,
@@ -163,7 +167,8 @@ export default Vue.extend({
             uri,
             data: c.el,
             scope: c.scope,
-            childComponents
+            childComponents,
+            slots
           },
           on: this.$listeners
         })

--- a/src/view/components/Node.vue
+++ b/src/view/components/Node.vue
@@ -36,6 +36,14 @@ export default Vue.extend({
   },
 
   computed: {
+    vnodeTag(): string | typeof Vue {
+      if (this.nodeUri) {
+        return ContainerVueComponent
+      }
+
+      return this.data.name
+    },
+
     vnodeData(): VNodeData {
       const { data: node, scope, selectable } = this
       const data = convertToVNodeData(
@@ -54,8 +62,8 @@ export default Vue.extend({
         }
       }
 
-      // If there is matched nodeUri, the vnode will be ContainerVueComponent
-      if (this.nodeUri) {
+      const tag = this.vnodeTag
+      if (tag === ContainerVueComponent) {
         data.props = {
           uri: this.nodeUri,
           propsData: data.attrs
@@ -144,10 +152,10 @@ export default Vue.extend({
   },
 
   render(h): VNode {
-    const { uri, data, childComponents } = this
+    const { uri, childComponents } = this
 
     return h(
-      this.nodeUri ? ContainerVueComponent : data.name,
+      this.vnodeTag,
       this.vnodeData,
       this.resolvedChildren.map(c => {
         return h(Child, {

--- a/src/view/components/Node.vue
+++ b/src/view/components/Node.vue
@@ -162,6 +162,7 @@ export default Vue.extend({
       this.vnodeTag,
       this.vnodeData,
       this.resolvedChildren.map(c => {
+        // Slot name will be resolved in <Child> component
         return h(Child, {
           props: {
             uri,

--- a/src/view/components/NodeSlot.vue
+++ b/src/view/components/NodeSlot.vue
@@ -24,21 +24,34 @@ export default Vue.extend({
     childComponents: {
       type: Array as { (): ChildComponent[] },
       required: true
+    },
+    slots: {
+      type: Object as { (): Record<string, VNode[]> },
+      required: true
     }
   },
 
-  render(h, { props }): VNode {
-    // @ts-ignore
-    return props.data.children.map(child => {
-      return h(Node, {
-        props: {
-          uri: props.uri,
-          data: child,
-          scope: props.scope,
-          childComponents: props.childComponents
-        }
+  render(h, { props }): any /* VNode[] */ {
+    const { data, slots } = props
+    const slotAttr = data.startTag.attributes.find(attr => attr.name === 'slot')
+    const slot = slots[slotAttr ? slotAttr.value : 'default']
+
+    if (!slot) {
+      // placeholder content
+      return props.data.children.map(child => {
+        return h(Node, {
+          props: {
+            uri: props.uri,
+            data: child,
+            scope: props.scope,
+            childComponents: props.childComponents,
+            slots
+          }
+        })
       })
-    })
+    }
+
+    return slot
   }
 })
 </script>

--- a/src/view/components/NodeSlot.vue
+++ b/src/view/components/NodeSlot.vue
@@ -33,7 +33,7 @@ export default Vue.extend({
 
   render(h, { props }): any /* VNode[] */ {
     const { data, slots } = props
-    const slotAttr = data.startTag.attributes.find(attr => attr.name === 'slot')
+    const slotAttr = data.startTag.attributes.find(attr => attr.name === 'name')
     const slot = slots[slotAttr ? slotAttr.value : 'default']
 
     if (!slot) {

--- a/src/view/components/NodeSlot.vue
+++ b/src/view/components/NodeSlot.vue
@@ -1,0 +1,44 @@
+<script lang="ts">
+import Vue, { VNode } from 'vue'
+import Node from './Node.vue'
+import { Element } from '@/parser/template/types'
+import { DefaultValue, ChildComponent } from '@/parser/script/types'
+
+export default Vue.extend({
+  name: 'NodeSlot',
+  functional: true,
+
+  props: {
+    uri: {
+      type: String,
+      required: true
+    },
+    data: {
+      type: Object as { (): Element },
+      required: true
+    },
+    scope: {
+      type: Object as { (): Record<string, DefaultValue> },
+      required: true
+    },
+    childComponents: {
+      type: Array as { (): ChildComponent[] },
+      required: true
+    }
+  },
+
+  render(h, { props }): VNode {
+    // @ts-ignore
+    return props.data.children.map(child => {
+      return h(Node, {
+        props: {
+          uri: props.uri,
+          data: child,
+          scope: props.scope,
+          childComponents: props.childComponents
+        }
+      })
+    })
+  }
+})
+</script>

--- a/src/view/components/NodeSlot.vue
+++ b/src/view/components/NodeSlot.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import Vue, { VNode } from 'vue'
-import Node from './Node.vue'
+import Child from './Child.vue'
 import { Element } from '@/parser/template/types'
 import { DefaultValue, ChildComponent } from '@/parser/script/types'
 
@@ -39,7 +39,7 @@ export default Vue.extend({
     if (!slot) {
       // placeholder content
       return props.data.children.map(child => {
-        return h(Node, {
+        return h(Child, {
           props: {
             uri: props.uri,
             data: child,

--- a/src/view/components/VueComponent.vue
+++ b/src/view/components/VueComponent.vue
@@ -70,7 +70,8 @@ export default Vue.extend({
                 uri: this.uri,
                 data: child.el,
                 scope: child.scope,
-                childComponents: this.childComponents
+                childComponents: this.childComponents,
+                slots: this.$slots
               },
               on: {
                 select: (path: number[]) => {

--- a/test/view/VueComponent/__snapshots__/slot.spec.ts.snap
+++ b/test/view/VueComponent/__snapshots__/slot.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VueComponent slot shows default elements 1`] = `"<div><style></style><div class=\\"\\"><p class=\\"\\">default content</p></div></div>"`;

--- a/test/view/VueComponent/__snapshots__/slot.spec.ts.snap
+++ b/test/view/VueComponent/__snapshots__/slot.spec.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VueComponent slot renders named slot content 1`] = `"<div><style></style><div class=\\"\\"><style></style><div data-scope-scope-id=\\"\\" class=\\"\\"><p data-scope-scope-id=\\"\\" class=\\"\\">foo content</p><p slot=\\"test\\" class=\\"\\">named</p></div></div></div>"`;
+
 exports[`VueComponent slot renders placeholder slot content 1`] = `"<div><style></style><div class=\\"\\"><p class=\\"\\">placeholder content</p></div></div>"`;
 
 exports[`VueComponent slot renders slot content 1`] = `"<div><style></style><div class=\\"\\"><style></style><div data-scope-scope-id=\\"\\" class=\\"\\"><p data-scope-scope-id=\\"\\" class=\\"\\">foo content</p><p class=\\"\\">injected</p></div></div></div>"`;

--- a/test/view/VueComponent/__snapshots__/slot.spec.ts.snap
+++ b/test/view/VueComponent/__snapshots__/slot.spec.ts.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VueComponent slot shows default elements 1`] = `"<div><style></style><div class=\\"\\"><p class=\\"\\">default content</p></div></div>"`;
+exports[`VueComponent slot renders placeholder slot content 1`] = `"<div><style></style><div class=\\"\\"><p class=\\"\\">placeholder content</p></div></div>"`;
+
+exports[`VueComponent slot renders slot content 1`] = `"<div><style></style><div class=\\"\\"><style></style><div data-scope-scope-id=\\"\\" class=\\"\\"><p data-scope-scope-id=\\"\\" class=\\"\\">foo content</p><p class=\\"\\">injected</p></div></div></div>"`;

--- a/test/view/VueComponent/slot.spec.ts
+++ b/test/view/VueComponent/slot.spec.ts
@@ -1,4 +1,4 @@
-import { createTemplate, h, render } from '../../helpers/template'
+import { createTemplate, h, render, a } from '../../helpers/template'
 
 describe('VueComponent slot', () => {
   it('renders placeholder slot content', () => {
@@ -30,6 +30,43 @@ describe('VueComponent slot', () => {
           h('div', [], [
             h('p', [], ['foo content']),
             h('slot', [], [])
+          ])
+        ])
+      }
+    }
+
+    const wrapper = render(
+      template,
+      [],
+      [],
+      [
+        {
+          name: 'Foo',
+          uri: 'file://Foo.vue'
+        }
+      ],
+      components
+    )
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders named slot content', () => {
+    // prettier-ignore
+    const template = createTemplate([
+      h('Foo', [], [
+        h('p', [], ['default']),
+        h('p', [a('slot', 'test')], ['named'])
+      ])
+    ])
+
+    const components = {
+      'file://Foo.vue': {
+        // prettier-ignore
+        template: createTemplate([
+          h('div', [], [
+            h('p', [], ['foo content']),
+            h('slot', [a('name', 'test')], [])
           ])
         ])
       }

--- a/test/view/VueComponent/slot.spec.ts
+++ b/test/view/VueComponent/slot.spec.ts
@@ -1,17 +1,53 @@
 import { createTemplate, h, render } from '../../helpers/template'
 
 describe('VueComponent slot', () => {
-  it('shows default elements', () => {
+  it('renders placeholder slot content', () => {
     // prettier-ignore
     const template = createTemplate([
       h('div', [], [
         h('slot', [], [
-          h('p', [], ['default content'])
+          h('p', [], ['placeholder content'])
         ])
       ])
     ])
 
     const wrapper = render(template)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders slot content', () => {
+    // prettier-ignore
+    const template = createTemplate([
+      h('Foo', [], [
+        h('p', [], ['injected'])
+      ])
+    ])
+
+    const components = {
+      'file://Foo.vue': {
+        // prettier-ignore
+        template: createTemplate([
+          h('div', [], [
+            h('p', [], ['foo content']),
+            h('slot', [], [])
+          ])
+        ])
+      }
+    }
+
+    const wrapper = render(
+      template,
+      [],
+      [],
+      [
+        {
+          name: 'Foo',
+          uri: 'file://Foo.vue'
+        }
+      ],
+      components
+    )
+
     expect(wrapper.html()).toMatchSnapshot()
   })
 })

--- a/test/view/VueComponent/slot.spec.ts
+++ b/test/view/VueComponent/slot.spec.ts
@@ -1,0 +1,17 @@
+import { createTemplate, h, render } from '../../helpers/template'
+
+describe('VueComponent slot', () => {
+  it('shows default elements', () => {
+    // prettier-ignore
+    const template = createTemplate([
+      h('div', [], [
+        h('slot', [], [
+          h('p', [], ['default content'])
+        ])
+      ])
+    ])
+
+    const wrapper = render(template)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
Vue Designer renders slot contents after this PR. Scoped slots are not supported yet.

As the further work, we need to edit slot content of previewing component so that we can confirm how it looks like in preview pane as same as props / data.