### PR TITLE
feat: resolve template element having control directives

### DIFF
--- a/test/view/VueComponent/__snapshots__/else-if.spec.ts.snap
+++ b/test/view/VueComponent/__snapshots__/else-if.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VueComponent v-else-if resolves template children as the else-if block 1`] = `"<div><style></style><strong class=\\"\\">Bar</strong>Content</div>"`;

--- a/test/view/VueComponent/__snapshots__/else.spec.ts.snap
+++ b/test/view/VueComponent/__snapshots__/else.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VueComponent v-else resolves template children as the else block 1`] = `"<div><style></style><strong class=\\"\\">Bar</strong>Content</div>"`;

--- a/test/view/VueComponent/__snapshots__/for.spec.ts.snap
+++ b/test/view/VueComponent/__snapshots__/for.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VueComponent v-for repeats template element children 1`] = `"<div><style></style><div class=\\"\\"><strong class=\\"\\">first - <span class=\\"\\">1</span></strong><small class=\\"\\">second - <span class=\\"\\">1</span></small><strong class=\\"\\">first - <span class=\\"\\">2</span></strong><small class=\\"\\">second - <span class=\\"\\">2</span></small><strong class=\\"\\">first - <span class=\\"\\">3</span></strong><small class=\\"\\">second - <span class=\\"\\">3</span></small></div></div>"`;

--- a/test/view/VueComponent/__snapshots__/if.spec.ts.snap
+++ b/test/view/VueComponent/__snapshots__/if.spec.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VueComponent v-if gathers the contents in the template element 1`] = `"<div><style></style><p class=\\"\\">foo</p>barbaz</div>"`;
+
+exports[`VueComponent v-if gathers the contents in the template element 2`] = `"<div><style></style>baz</div>"`;

--- a/test/view/VueComponent/else-if.spec.ts
+++ b/test/view/VueComponent/else-if.spec.ts
@@ -58,4 +58,20 @@ describe('VueComponent v-else-if', () => {
     expect(list.length).toBe(1)
     expect(list.at(0).text()).toBe('Bar')
   })
+
+  it('resolves template children as the else-if block', () => {
+    // prettier-ignore
+    const template = createTemplate([
+      h('p', [d('if', 'false')], [
+        'Foo'
+      ]),
+      h('template', [d('else-if', 'true')], [
+        h('strong', [], ['Bar']),
+        'Content'
+      ])
+    ])
+
+    const wrapper = render(template)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/test/view/VueComponent/else.spec.ts
+++ b/test/view/VueComponent/else.spec.ts
@@ -125,4 +125,20 @@ describe('VueComponent v-else', () => {
     expect(baz.exists()).toBe(false)
     expect(qux.exists()).toBe(false)
   })
+
+  it('resolves template children as the else block', () => {
+    // prettier-ignore
+    const template = createTemplate([
+      h('p', [d('if', 'false')], [
+        'Foo'
+      ]),
+      h('template', [d('else')], [
+        h('strong', [], ['Bar']),
+        'Content'
+      ])
+    ])
+
+    const wrapper = render(template)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/test/view/VueComponent/for.spec.ts
+++ b/test/view/VueComponent/for.spec.ts
@@ -104,4 +104,19 @@ describe('VueComponent v-for', () => {
     const list = wrapper.findAll('li')
     expect(list.length).toBe(0)
   })
+
+  it('repeats template element children', () => {
+    // prettier-ignore
+    const template = createTemplate([
+      h('div', [], [
+        h('template', [vFor(['i'], '3')], [
+          h('strong', [], ['first - ', exp('i')]),
+          h('small', [], ['second - ', exp('i')])
+        ])
+      ])
+    ])
+
+    const wrapper = render(template)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/test/view/VueComponent/if.spec.ts
+++ b/test/view/VueComponent/if.spec.ts
@@ -77,4 +77,28 @@ describe('VueComponent v-if', () => {
     const p = render(template).find('p')
     expect(p.exists()).toBe(false)
   })
+
+  it('gathers the contents in the template element', () => {
+    // prettier-ignore
+    const shown = createTemplate([
+      h('template', [d('if', 'true')], [
+        h('p', [], ['foo']),
+        'bar'
+      ]),
+      'baz'
+    ])
+
+    expect(render(shown).html()).toMatchSnapshot()
+
+    // prettier-ignore
+    const hidden = createTemplate([
+      h('template', [d('if', 'false')], [
+        h('p', [], ['foo']),
+        'bar'
+      ]),
+      'baz'
+    ])
+
+    expect(render(hidden).html()).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
`v-if`, `v-else`, `v-else-if` and `v-for` can be used on `<template>` element and the rendered html will not have the element. It expands the children of the `<template>`.

References:

* https://vuejs.org/v2/guide/conditional.html#Conditional-Groups-with-v-if-on-lt-template-gt
* https://vuejs.org/v2/guide/list.html#v-for-on-a-lt-template-gt