### PR TITLE
feat: resolve a template tag of an injected named slot

### DIFF
--- a/test/view/VueComponent/__snapshots__/slot.spec.ts.snap
+++ b/test/view/VueComponent/__snapshots__/slot.spec.ts.snap
@@ -5,3 +5,5 @@ exports[`VueComponent slot renders named slot content 1`] = `"<div><style></styl
 exports[`VueComponent slot renders placeholder slot content 1`] = `"<div><style></style><div class=\\"\\"><p class=\\"\\">placeholder content</p></div></div>"`;
 
 exports[`VueComponent slot renders slot content 1`] = `"<div><style></style><div class=\\"\\"><style></style><div data-scope-scope-id=\\"\\" class=\\"\\"><p data-scope-scope-id=\\"\\" class=\\"\\">foo content</p><p class=\\"\\">injected</p></div></div></div>"`;
+
+exports[`VueComponent slot resolves template element children as the named slot 1`] = `"<div><style></style><div class=\\"\\"><style></style><div data-scope-scope-id=\\"\\" class=\\"\\"><strong class=\\"\\">named</strong><span class=\\"\\">content</span></div></div></div>"`;

--- a/test/view/VueComponent/slot.spec.ts
+++ b/test/view/VueComponent/slot.spec.ts
@@ -87,4 +87,42 @@ describe('VueComponent slot', () => {
 
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  it('resolves template element children as the named slot', () => {
+    // prettier-ignore
+    const template = createTemplate([
+      h('Foo', [], [
+        h('template', [a('slot', 'test')], [
+          h('strong', [], ['named']),
+          h('span', [], ['content'])
+        ])
+      ])
+    ])
+
+    const components = {
+      'file://Foo.vue': {
+        // prettier-ignore
+        template: createTemplate([
+          h('div', [], [
+            h('slot', [a('name', 'test')], [])
+          ])
+        ])
+      }
+    }
+
+    const wrapper = render(
+      template,
+      [],
+      [],
+      [
+        {
+          name: 'Foo',
+          uri: 'file://Foo.vue'
+        }
+      ],
+      components
+    )
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
If the `<template>` element is an injected named slot, it should be disappeared from the rendered output.

Reference:
- https://vuejs.org/v2/guide/components-slots.html#Named-Slots
