### PR TITLE
feat: support rendering scoped slots

### DIFF
--- a/src/view/components/Child.vue
+++ b/src/view/components/Child.vue
@@ -35,6 +35,11 @@ const Child = Vue.extend({
     slots: {
       type: Object as { (): Record<string, VNode[]> },
       required: true
+    },
+
+    scopedSlots: {
+      type: Object,
+      required: true
     }
   },
 

--- a/src/view/components/ContainerNode.vue
+++ b/src/view/components/ContainerNode.vue
@@ -47,6 +47,11 @@ export default Vue.extend({
     slots: {
       type: Object as { (): Record<string, VNode[]> },
       required: true
+    },
+
+    scopedSlots: {
+      type: Object,
+      required: true
     }
   },
 

--- a/src/view/components/ContainerVueComponent.vue
+++ b/src/view/components/ContainerVueComponent.vue
@@ -62,7 +62,8 @@ export default Vue.extend({
           childComponents: this.document.childComponents,
           styles: this.document.styleCode,
           propsData: this.propsData
-        }
+        },
+        scopedSlots: this.$scopedSlots
       },
       flattenSlots
     )

--- a/src/view/components/VueComponent.vue
+++ b/src/view/components/VueComponent.vue
@@ -71,7 +71,8 @@ export default Vue.extend({
                 data: child.el,
                 scope: child.scope,
                 childComponents: this.childComponents,
-                slots: this.$slots
+                slots: this.$slots,
+                scopedSlots: this.$scopedSlots
               },
               on: {
                 select: (path: number[]) => {

--- a/test/view/VueComponent/__snapshots__/scoped-slot.spec.ts.snap
+++ b/test/view/VueComponent/__snapshots__/scoped-slot.spec.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VueComponent scoped slot renders named scoped slot content 1`] = `"<div><style></style><div class=\\"\\"><style></style><div data-scope-scope-id=\\"\\" class=\\"\\"><p data-scope-scope-id=\\"\\" class=\\"\\">foo content</p><p slot-scope=\\"props\\" class=\\"\\"><span class=\\"\\">test1</span></p><p slot-scope=\\"props\\" class=\\"\\"><span class=\\"\\">test2</span></p></div></div></div>"`;
+
+exports[`VueComponent scoped slot renders scoped slot content 1`] = `"<div><style></style><div class=\\"\\"><style></style><div data-scope-scope-id=\\"\\" class=\\"\\"><p data-scope-scope-id=\\"\\" class=\\"\\">foo content</p><p slot-scope=\\"props\\" class=\\"\\"><span class=\\"\\">test</span></p></div></div></div>"`;
+
+exports[`VueComponent scoped slot resolves template element children as a slot 1`] = `"<div><style></style><div class=\\"\\"><style></style><div data-scope-scope-id=\\"\\" class=\\"\\"><strong class=\\"\\">named</strong><span class=\\"\\"><span class=\\"\\">test</span></span></div></div></div>"`;

--- a/test/view/VueComponent/__snapshots__/slot.spec.ts.snap
+++ b/test/view/VueComponent/__snapshots__/slot.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VueComponent slot renders named slot content 1`] = `"<div><style></style><div class=\\"\\"><style></style><div data-scope-scope-id=\\"\\" class=\\"\\"><p data-scope-scope-id=\\"\\" class=\\"\\">foo content</p><p slot=\\"test\\" class=\\"\\">named</p></div></div></div>"`;
+exports[`VueComponent slot renders named slot content 1`] = `"<div><style></style><div class=\\"\\"><style></style><div data-scope-scope-id=\\"\\" class=\\"\\"><p data-scope-scope-id=\\"\\" class=\\"\\">foo content</p><p class=\\"\\">named</p></div></div></div>"`;
 
 exports[`VueComponent slot renders placeholder slot content 1`] = `"<div><style></style><div class=\\"\\"><p class=\\"\\">placeholder content</p></div></div>"`;
 

--- a/test/view/VueComponent/scoped-slot.spec.ts
+++ b/test/view/VueComponent/scoped-slot.spec.ts
@@ -1,0 +1,115 @@
+import { createTemplate, h, render, a, exp } from '../../helpers/template'
+
+describe('VueComponent scoped slot', () => {
+  it('renders scoped slot content', () => {
+    // prettier-ignore
+    const template = createTemplate([
+      h('Foo', [], [
+        h('p', [a('slot-scope', 'props')], [exp('props.foo')])
+      ])
+    ])
+
+    const components = {
+      'file://Foo.vue': {
+        // prettier-ignore
+        template: createTemplate([
+          h('div', [], [
+            h('p', [], ['foo content']),
+            h('slot', [a('foo', 'test')], [])
+          ])
+        ])
+      }
+    }
+
+    const wrapper = render(
+      template,
+      [],
+      [],
+      [
+        {
+          name: 'Foo',
+          uri: 'file://Foo.vue'
+        }
+      ],
+      components
+    )
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders named scoped slot content', () => {
+    // prettier-ignore
+    const template = createTemplate([
+      h('Foo', [], [
+        h('p', [a('slot-scope', 'props')], [exp('props.foo')]),
+        h('p', [a('slot', 'test'), a('slot-scope', 'props')], [exp('props.foo')])
+      ])
+    ])
+
+    const components = {
+      'file://Foo.vue': {
+        // prettier-ignore
+        template: createTemplate([
+          h('div', [], [
+            h('p', [], ['foo content']),
+            h('slot', [a('foo', 'test1')], []),
+            h('slot', [a('name', 'test'), a('foo', 'test2')], [])
+          ])
+        ])
+      }
+    }
+
+    const wrapper = render(
+      template,
+      [],
+      [],
+      [
+        {
+          name: 'Foo',
+          uri: 'file://Foo.vue'
+        }
+      ],
+      components
+    )
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('resolves template element children as a slot', () => {
+    // prettier-ignore
+    const template = createTemplate([
+      h('Foo', [], [
+        h('template', [a('slot-scope', 'props')], [
+          h('strong', [], ['named']),
+          h('span', [], [exp('props.foo')])
+        ])
+      ])
+    ])
+
+    const components = {
+      'file://Foo.vue': {
+        // prettier-ignore
+        template: createTemplate([
+          h('div', [], [
+            h('slot', [a('foo', 'test')], [])
+          ])
+        ])
+      }
+    }
+
+    const wrapper = render(
+      template,
+      [],
+      [],
+      [
+        {
+          name: 'Foo',
+          uri: 'file://Foo.vue'
+        }
+      ],
+      components
+    )
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
This PR adds support for scoped slots rendering.

As the implementation is a bit messy, we need to refactor it later. 
I guess, the attribute field of element AST should be a hash map instead of an array because I write like `attributes.find(attr => attr.name === '....')` many times.