### PR TITLE
chore: add abstract module for web socket communication

### DIFF
--- a/src/infra/communication/connect.ts
+++ b/src/infra/communication/connect.ts
@@ -1,0 +1,98 @@
+import assert from 'assert'
+import { Subject } from './subject'
+import { Observer } from './observer'
+
+type Resolver<T> = Record<string, (...args: any[]) => T | T[] | undefined>
+type Mutator = Record<string, (...args: any[]) => void>
+
+export interface WebSocketServer {
+  on(event: 'connection', cb: (socket: WebSocket) => void): void
+}
+
+export interface WebSocket {
+  send(payload: string): void
+  on(event: 'message', cb: (message: string) => void): void
+  once(event: 'close', cb: () => void): void
+}
+
+export interface ConnectConfig<T> {
+  resolver: Resolver<T>
+  mutator: Mutator
+  subject: Subject<T>
+  server: WebSocketServer
+}
+
+export function connectWsServer<T>({
+  resolver,
+  mutator,
+  subject,
+  server
+}: ConnectConfig<T>): void {
+  server.on('connection', ws => {
+    connectSubject(ws, subject)
+    listenMessage(ws, resolver, mutator)
+  })
+}
+
+function listenMessage(
+  ws: WebSocket,
+  resolver: Resolver<{}>,
+  mutator: Mutator
+) {
+  ws.on('message', message => {
+    const data = JSON.parse(message.toString())
+    const [type, method] = data.type.split(':')
+    const target = type === 'resolver' ? resolver : mutator
+
+    assert(type === 'resolver' || type === 'mutator')
+    assert(Array.isArray(data.args))
+    assert(typeof data.requestId === 'string')
+    assert(typeof method === 'string')
+    assert(typeof target[method] === 'function')
+
+    const res = target[method].apply(target, data.args)
+    ws.send(
+      JSON.stringify({
+        type: data.type,
+        data: res,
+        requestId: data.requestId
+      })
+    )
+  })
+}
+
+function connectSubject(ws: WebSocket, subject: Subject<{}>): void {
+  const observer: Observer<{}> = {
+    onAdd(data) {
+      ws.send(
+        JSON.stringify({
+          type: 'subject:add',
+          data
+        })
+      )
+    },
+
+    onUpdate(data) {
+      ws.send(
+        JSON.stringify({
+          type: 'subject:update',
+          data
+        })
+      )
+    },
+
+    onRemove(data) {
+      ws.send(
+        JSON.stringify({
+          type: 'subject:remove',
+          data
+        })
+      )
+    }
+  }
+
+  subject.on(observer)
+  ws.once('close', () => {
+    subject.off(observer)
+  })
+}

--- a/src/infra/communication/connect.ts
+++ b/src/infra/communication/connect.ts
@@ -1,9 +1,6 @@
 import assert from 'assert'
 import { Subject } from './subject'
-import { Observer } from './observer'
-
-type Resolver<T> = Record<string, (...args: any[]) => T | T[] | undefined>
-type Mutator = Record<string, (...args: any[]) => void>
+import { Observer, Resolver, Mutator } from './types'
 
 export interface WebSocketServer {
   on(event: 'connection', cb: (socket: WebSocket) => void): void

--- a/src/infra/communication/connect.ts
+++ b/src/infra/communication/connect.ts
@@ -38,13 +38,15 @@ function listenMessage(
 ) {
   ws.on('message', message => {
     const data = JSON.parse(message.toString())
+
+    assert(typeof data.type === 'string')
+    assert(Array.isArray(data.args))
+    assert('requestId' in data)
+
     const [type, method] = data.type.split(':')
     const target = type === 'resolver' ? resolver : mutator
 
     assert(type === 'resolver' || type === 'mutator')
-    assert(Array.isArray(data.args))
-    assert(typeof data.requestId === 'string')
-    assert(typeof method === 'string')
     assert(typeof target[method] === 'function')
 
     const res = target[method].apply(target, data.args)

--- a/src/infra/communication/observer.ts
+++ b/src/infra/communication/observer.ts
@@ -1,0 +1,5 @@
+export interface Observer<T> {
+  onAdd(value: T): void
+  onUpdate(value: T): void
+  onRemove(value: T): void
+}

--- a/src/infra/communication/observer.ts
+++ b/src/infra/communication/observer.ts
@@ -1,5 +1,0 @@
-export interface Observer<T> {
-  onAdd(value: T): void
-  onUpdate(value: T): void
-  onRemove(value: T): void
-}

--- a/src/infra/communication/subject.ts
+++ b/src/infra/communication/subject.ts
@@ -1,0 +1,31 @@
+import { Observer } from './observer'
+
+export class Subject<T> {
+  private observers = new Set<Observer<T>>()
+
+  on(observer: Observer<T>): void {
+    this.observers.add(observer)
+  }
+
+  off(observer: Observer<T>): void {
+    this.observers.delete(observer)
+  }
+
+  notifyAdd(value: T): void {
+    this.observers.forEach(ob => {
+      ob.onAdd(value)
+    })
+  }
+
+  notifyUpdate(value: T): void {
+    this.observers.forEach(ob => {
+      ob.onUpdate(value)
+    })
+  }
+
+  notifyRemove(value: T): void {
+    this.observers.forEach(ob => {
+      ob.onRemove(value)
+    })
+  }
+}

--- a/src/infra/communication/subject.ts
+++ b/src/infra/communication/subject.ts
@@ -1,4 +1,4 @@
-import { Observer } from './observer'
+import { Observer } from './types'
 
 export class Subject<T> {
   private observers = new Set<Observer<T>>()

--- a/src/infra/communication/types.ts
+++ b/src/infra/communication/types.ts
@@ -1,0 +1,12 @@
+export interface Observer<T> {
+  onAdd(value: T): void
+  onUpdate(value: T): void
+  onRemove(value: T): void
+}
+
+export type Resolver<T> = Record<
+  string,
+  (...args: any[]) => T | T[] | undefined
+>
+
+export type Mutator = Record<string, (...args: any[]) => void>

--- a/tests/helpers/ws.ts
+++ b/tests/helpers/ws.ts
@@ -13,17 +13,32 @@ export class MockWebSocketServer extends EventEmitter
 class MockWebSocketClient {
   connection: MockWebSocket
   received: any[] = []
+  private closed = false
 
   constructor() {
     this.connection = new MockWebSocket(this)
   }
 
   send(payload: any): void {
+    this.assertConnection()
     this.connection.emit('message', JSON.stringify(payload))
   }
 
   close(): void {
+    this.assertConnection()
     this.connection.emit('close')
+    this.closed = true
+  }
+
+  pushMessage(payload: string): void {
+    this.assertConnection()
+    this.received.push(JSON.parse(payload))
+  }
+
+  assertConnection(): void {
+    if (this.closed) {
+      throw new Error('already closed')
+    }
   }
 }
 
@@ -33,6 +48,6 @@ class MockWebSocket extends EventEmitter implements WebSocket {
   }
 
   send(payload: string): void {
-    this.client.received.push(JSON.parse(payload))
+    this.client.pushMessage(payload)
   }
 }

--- a/tests/helpers/ws.ts
+++ b/tests/helpers/ws.ts
@@ -1,0 +1,38 @@
+import { EventEmitter } from 'events'
+import { WebSocket, WebSocketServer } from '@/infra/communication/connect'
+
+export class MockWebSocketServer extends EventEmitter
+  implements WebSocketServer {
+  connectClient(): MockWebSocketClient {
+    const client = new MockWebSocketClient()
+    this.emit('connection', client.connection)
+    return client
+  }
+}
+
+class MockWebSocketClient {
+  connection: MockWebSocket
+  received: any[] = []
+
+  constructor() {
+    this.connection = new MockWebSocket(this)
+  }
+
+  send(payload: any): void {
+    this.connection.emit('message', JSON.stringify(payload))
+  }
+
+  close(): void {
+    this.connection.emit('close')
+  }
+}
+
+class MockWebSocket extends EventEmitter implements WebSocket {
+  constructor(private client: MockWebSocketClient) {
+    super()
+  }
+
+  send(payload: string): void {
+    this.client.received.push(JSON.parse(payload))
+  }
+}

--- a/tests/infra/communication/connect.spec.ts
+++ b/tests/infra/communication/connect.spec.ts
@@ -1,0 +1,188 @@
+import { Subject } from '@/infra/communication/subject'
+import { connectWsServer } from '@/infra/communication/connect'
+import { MockWebSocketServer } from '../../helpers/ws'
+
+describe('Communication infra', () => {
+  interface Foo {
+    id: string
+    value: string
+  }
+
+  let mockServer: MockWebSocketServer
+  let mockSubject: Subject<any>
+  let dummyData: Foo[]
+
+  beforeEach(() => {
+    mockServer = new MockWebSocketServer()
+    mockSubject = new Subject()
+
+    dummyData = [
+      {
+        id: '1',
+        value: 'test'
+      },
+      {
+        id: '2',
+        value: 'test 2'
+      }
+    ]
+  })
+
+  describe('resolver', () => {
+    const resolver = {
+      get(id: string): Foo | undefined {
+        return dummyData.find(d => d.id === id)
+      },
+
+      all(): Foo[] {
+        return dummyData
+      }
+    }
+
+    beforeEach(() => {
+      connectWsServer({
+        resolver,
+        mutator: {},
+        subject: mockSubject,
+        server: mockServer
+      })
+    })
+
+    it('resolves a value with a resolver method', () => {
+      const ws = mockServer.connectClient()
+
+      ws.send({
+        type: 'resolver:get',
+        args: ['2'],
+        requestId: '1'
+      })
+
+      expect(ws.received.length).toBe(1)
+      const res = ws.received[0]
+
+      expect(res.type).toBe('resolver:get')
+      expect(res.data).toEqual(dummyData[1])
+      expect(res.requestId).toBe('1')
+    })
+
+    it('resolves values with a resolver method', () => {
+      const ws = mockServer.connectClient()
+
+      ws.send({
+        type: 'resolver:all',
+        args: [],
+        requestId: '2'
+      })
+
+      expect(ws.received.length).toBe(1)
+      const res = ws.received[0]
+
+      expect(res.type).toBe('resolver:all')
+      expect(res.data).toEqual(dummyData)
+      expect(res.requestId).toBe('2')
+    })
+  })
+
+  describe('mutator', () => {
+    const mutator = {
+      update(id: string, value: string): void {
+        const data = dummyData.find(d => d.id === id)
+        if (data) {
+          data.value = value
+        }
+      }
+    }
+
+    beforeEach(() => {
+      connectWsServer({
+        resolver: {},
+        mutator,
+        subject: mockSubject,
+        server: mockServer
+      })
+    })
+
+    it('mutates a value with a mutator method', () => {
+      const ws = mockServer.connectClient()
+
+      ws.send({
+        type: 'mutator:update',
+        args: ['2', 'updated'],
+        requestId: '1'
+      })
+
+      expect(ws.received.length).toBe(1)
+      const res = ws.received[0]
+
+      expect(res.type).toBe('mutator:update')
+      expect(res.requestId).toBe('1')
+
+      expect(dummyData[1]).toEqual({
+        id: '2',
+        value: 'updated'
+      })
+    })
+  })
+
+  describe('subject', () => {
+    beforeEach(() => {
+      connectWsServer({
+        resolver: {},
+        mutator: {},
+        subject: mockSubject,
+        server: mockServer
+      })
+    })
+
+    it('notifies that some value is added', () => {
+      const ws = mockServer.connectClient()
+
+      const data = {
+        id: '3',
+        value: 'test'
+      }
+
+      mockSubject.notifyAdd(data)
+
+      expect(ws.received.length).toBe(1)
+      const res = ws.received[0]
+
+      expect(res.type).toBe('subject:add')
+      expect(res.data).toEqual(data)
+    })
+
+    it('notifies that some value is updateded', () => {
+      const ws = mockServer.connectClient()
+
+      const data = {
+        id: '2',
+        value: 'test'
+      }
+
+      mockSubject.notifyUpdate(data)
+
+      expect(ws.received.length).toBe(1)
+      const res = ws.received[0]
+
+      expect(res.type).toBe('subject:update')
+      expect(res.data).toEqual(data)
+    })
+
+    it('notifies that some value is removed', () => {
+      const ws = mockServer.connectClient()
+
+      const data = {
+        id: '1',
+        value: 'test'
+      }
+
+      mockSubject.notifyRemove(data)
+
+      expect(ws.received.length).toBe(1)
+      const res = ws.received[0]
+
+      expect(res.type).toBe('subject:remove')
+      expect(res.data).toEqual(data)
+    })
+  })
+})

--- a/tests/infra/communication/connect.spec.ts
+++ b/tests/infra/communication/connect.spec.ts
@@ -184,5 +184,18 @@ describe('Communication infra', () => {
       expect(res.type).toBe('subject:remove')
       expect(res.data).toEqual(data)
     })
+
+    it('unsubscribe observer after the connection is closed', () => {
+      const ws = mockServer.connectClient()
+
+      const data = {
+        id: '1',
+        value: 'updated'
+      }
+
+      ws.close()
+      mockSubject.notifyUpdate(data)
+      expect(ws.received.length).toBe(0)
+    })
   })
 })


### PR DESCRIPTION
ref #48 

This PR adds an abstract server side module for websocket communication.
It has a concept like GraphQL but handle simple method-based api and supports nested data structure.

The users of this module should create `Resolver`, `Mutator` and `Subject` at first.
Resolver is an object having methods that returning a data model by retrieving some repository. Mutator is also an object having methods but they are responsible to update the data model. Subject is for notifying events that the data is added / updated / removed. It is meant to be used by being extended by the repository class.

Then, the users connect them with their WebSocket server by using `connectWsServer` function.

By this module, we don't need to concern the low-level web socket communication. Just write high-level resolver, mutator and subject.

I'll implement the client side module on another PR.