### PR TITLE
perf: minimize edited content in a file

### DIFF
--- a/src/parser/modifier.ts
+++ b/src/parser/modifier.ts
@@ -58,6 +58,15 @@ export function modify(code: string, modfiers: Modifiers): string {
   return loop('', 0, ms[0], ms.slice(1))
 }
 
+export function reduce<T>(
+  modifiers: Modifiers,
+  fn: (acc: T, modifier: Modifier) => T,
+  initial: T
+): T {
+  const ms = flatten(modifiers).sort(modifierComperator)
+  return ms.reduce(fn, initial)
+}
+
 function modifierComperator(a: Modifier, b: Modifier): number {
   if (a.pos < b.pos) {
     return -1

--- a/src/vscode/modifier.ts
+++ b/src/vscode/modifier.ts
@@ -1,0 +1,35 @@
+import * as vscode from 'vscode'
+import { Modifiers, reduce } from '../parser/modifier'
+
+export async function applyModifiers(
+  uri: string,
+  modifiers: Modifiers
+): Promise<void> {
+  const parsedUri = vscode.Uri.parse(uri)
+  const doc = await vscode.workspace.openTextDocument(parsedUri)
+
+  const wsEdit = reduce(
+    modifiers,
+    (edit, m) => {
+      switch (m.type) {
+        case 'Add':
+          edit.insert(parsedUri, doc.positionAt(m.pos), m.value)
+          break
+        case 'Remove':
+          edit.delete(
+            parsedUri,
+            new vscode.Range(
+              doc.positionAt(m.pos),
+              doc.positionAt(m.pos + m.length)
+            )
+          )
+          break
+        default:
+      }
+      return edit
+    },
+    new vscode.WorkspaceEdit()
+  )
+
+  await vscode.workspace.applyEdit(wsEdit)
+}

--- a/src/vue-designer.ts
+++ b/src/vue-designer.ts
@@ -5,6 +5,7 @@ import debounce from 'lodash.debounce'
 import { startStaticServer, startWebSocketServer } from './server/main'
 import { AssetResolver } from './asset-resolver'
 import { Watcher } from './vscode/watcher'
+import { applyModifiers } from './vscode/modifier'
 import { VueFileRepository } from './repositories/vue-file-repository'
 import { SettingRepository } from './repositories/setting-repository'
 import { EditorRepository } from './repositories/editor-repository'
@@ -53,18 +54,8 @@ async function createVueFileRepository(): Promise<VueFileRepository> {
       return document.getText()
     },
 
-    async writeFile(uri, code) {
-      const parsedUri = vscode.Uri.parse(uri)
-      const doc = await vscode.workspace.openTextDocument(parsedUri)
-
-      const range = new vscode.Range(
-        doc.positionAt(0),
-        doc.positionAt(doc.getText().length)
-      )
-
-      const wsEdit = new vscode.WorkspaceEdit()
-      wsEdit.replace(parsedUri, range, code)
-      vscode.workspace.applyEdit(wsEdit)
+    modifyFile(uri, modifiers) {
+      return applyModifiers(uri, modifiers)
     }
   })
 

--- a/tests/parser/modifier.spec.ts
+++ b/tests/parser/modifier.spec.ts
@@ -4,11 +4,13 @@ import {
   insertBefore,
   insertAfter,
   remove,
-  replace
+  replace,
+  insertAt,
+  reduce
 } from '@/parser/modifier'
 import { transformTemplate } from '@/parser/template/transform'
 
-describe('Modifier', () => {
+describe('modify', () => {
   it('should insert string before specified range', () => {
     const code = 'const foo = "World";'
     const actual = modify(code, [
@@ -99,5 +101,31 @@ describe('Modifier', () => {
     ])
     const expected = 'let ;'
     expect(actual).toBe(expected)
+  })
+})
+
+describe('reduce', () => {
+  it('flattens and sorts the modifiers', () => {
+    const modifiers = [
+      insertAt(9, 'test'),
+      remove({ range: [0, 4] }),
+      replace({ range: [5, 10] }, 'foo')
+    ]
+
+    const r = reduce(
+      modifiers,
+      (acc, m) => {
+        return {
+          pos: m.pos,
+          result: acc.result && acc.pos <= m.pos
+        }
+      },
+      {
+        pos: 0,
+        result: true
+      }
+    )
+
+    expect(r.result).toBe(true)
   })
 })


### PR DESCRIPTION
The current implementation rewrite entire Vue SFC when it is edited from the preview pane. It is a bit expensive and occurs blinks of syntax highlight.

To minimize the updating range, I've let vue-repository module pass `Modifiers` object to external `modifyFile` function directly and the function update the document by using the modifiers information.